### PR TITLE
1.0.17

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -52,10 +52,10 @@ def prepare_environment():
 
 
 model_filenames = [
-    ('sd_xl_base_1.0.safetensors',
-     'https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0.safetensors'),
-    ('sd_xl_refiner_1.0.safetensors',
-     'https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0/resolve/main/sd_xl_refiner_1.0.safetensors')
+    ('sd_xl_base_1.0_0.9vae.safetensors',
+     'https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0_0.9vae.safetensors'),
+    ('sd_xl_refiner_1.0_0.9vae.safetensors',
+     'https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0/resolve/main/sd_xl_refiner_1.0_0.9vae.safetensors')
 ]
 
 lora_filenames = [

--- a/modules/default_pipeline.py
+++ b/modules/default_pipeline.py
@@ -5,8 +5,8 @@ import torch
 from modules.path import modelfile_path, lorafile_path
 
 
-xl_base_filename = os.path.join(modelfile_path, 'sd_xl_base_1.0.safetensors')
-xl_refiner_filename = os.path.join(modelfile_path, 'sd_xl_refiner_1.0.safetensors')
+xl_base_filename = os.path.join(modelfile_path, 'sd_xl_base_1.0_0.9vae.safetensors')
+xl_refiner_filename = os.path.join(modelfile_path, 'sd_xl_refiner_1.0_0.9vae.safetensors')
 xl_base_offset_lora_filename = os.path.join(lorafile_path, 'sd_xl_offset_example-lora_1.0.safetensors')
 
 xl_base = core.load_model(xl_base_filename)

--- a/readme.md
+++ b/readme.md
@@ -29,8 +29,8 @@ After you download the file, please uncompress it, and then run the "run.bat".
 
 In the first time you launch the software, it will automatically download models:
 
-1. It will download [sd_xl_base_1.0.safetensors from here](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0.safetensors) as the file "Fooocus\models\checkpoints\sd_xl_base_1.0.safetensors".
-2. It will download [sd_xl_refiner_1.0.safetensors from here](https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0/resolve/main/sd_xl_refiner_1.0.safetensors) as the file "Fooocus\models\checkpoints\sd_xl_refiner_1.0.safetensors".
+1. It will download [sd_xl_base_1.0_0.9vae.safetensors from here](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0_0.9vae.safetensors) as the file "Fooocus\models\checkpoints\sd_xl_base_1.0_0.9vae.safetensors".
+2. It will download [sd_xl_refiner_1.0_0.9vae.safetensors from here](https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0/resolve/main/sd_xl_refiner_1.0_0.9vae.safetensors) as the file "Fooocus\models\checkpoints\sd_xl_refiner_1.0_0.9vae.safetensors".
 
 If you already have these files, you can copy them to the above locations to speed up installation.
 

--- a/update_log.md
+++ b/update_log.md
@@ -1,3 +1,7 @@
+### 1.0.17
+
+* Change default model to SDXL-1.0-vae-0.9.
+
 ### 1.0.16
 
 * Implemented "Fooocus/outputs" folder for saving user results.

--- a/update_log.md
+++ b/update_log.md
@@ -1,6 +1,6 @@
 ### 1.0.17
 
-* Change default model to SDXL-1.0-vae-0.9.
+* Change default model to SDXL-1.0-vae-0.9. (This means the models will be downloaded again, but we should do it as early as possible so that all new users only need to download once. Really sorry for day-0 users. But frankly this is not too late considering that the project is just publicly available in less than 24 hours - if it has been a week then we will prefer more lightweight tricks to update.)
 
 ### 1.0.16
 


### PR DESCRIPTION
### 1.0.17

* Change default model to SDXL-1.0-vae-0.9. (This means the models will be downloaded again, but we should do it as early as possible so that all new users only need to download once. Really sorry for day-0 users. But frankly this is not too late considering that the project is just publicly available in less than 24 hours - if it has been a week then we will prefer more lightweight tricks to update.)