### PR TITLE
Update readme.md with macOS installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,17 @@ Or if you want to open a remote port, use
 
 ### Mac/Windows(AMD GPUs)
 
-Coming soon ...
+You can install Fooocus on Apple Mac silicon (M1 or M2) with macOS 'Catalina' or a newer version. Fooocus runs on Apple silicon computers via [PyTorch](https://pytorch.org/get-started/locally/) MPS device acceleration.
+
+> :point_up: Mac Silicon computers don't come with a dedicated graphics card, resulting in significantly longer image processing times compared to computers with dedicated graphics cards.
+
+1. Install the conda package manager and pytorch nightly. Read the [Accelerated PyTorch training on Mac](https://developer.apple.com/metal/pytorch/) Apple Developer guide for instructions. Make sure pytorch recognizes your MPS device.
+1. Open the macOS Terminal app and clone this repository with `git clone https://github.com/lllyasviel/Fooocus.git`.
+1. Change to the new Fooocus directory, `cd Fooocus`.
+1. Create a new conda environment, `conda env create -f environment.yaml`.
+1. Activate your new conda environment, `conda activate fooocus`.
+1. Install the packages required by Fooocus, `pip install -r requirements_versions.txt`.
+1. Launch Fooocus by running `python launch.py`. The first time you run Fooocus, it will automatically download the Stable Diffusion SDXL models and will take a significant time, depending on your internet connection.
 
 ## List of "Hidden" Tricks
 <a name="tech_list"></a>


### PR DESCRIPTION
Adds specific Mac M1/M2 installation instructions for Fooocus.

The same instructions for Linux work on Mac. The only prerequisite is the PyTorch installation, as described in the procedure.

On my M1 Mac, the installation and first run ran error-clean, and I could start generating images without any additional configuration.

![Screenshot 2023-08-15 at 3 02 58@2x](https://github.com/lllyasviel/Fooocus/assets/62282406/16d10952-9dbf-43cd-bc6f-3fb29cf37aac)
