### PR TITLE
Regarding the modification to save generation information in a json file

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -1,5 +1,5 @@
 import threading
-
+import json
 
 buffer = []
 outputs = []
@@ -69,12 +69,15 @@ def worker():
                 y)])
 
         for i in range(image_number):
-            imgs = pipeline.process(p_txt, n_txt, steps, switch, width, height, seed, callback=callback)
+            imgs, jsons = pipeline.process(p_txt, n_txt, steps, switch, width, height, seed, callback=callback)
 
-            for x in imgs:
+            for x, json_data in zip(imgs, jsons):
                 local_temp_filename = generate_temp_filename(folder=modules.path.temp_outputs_path, extension='png')
+                local_json_filename = os.path.splitext(local_temp_filename)[0] + ".json"
                 os.makedirs(os.path.dirname(local_temp_filename), exist_ok=True)
                 Image.fromarray(x).save(local_temp_filename)
+                with open(local_json_filename, "w") as json_file:
+                    json.dump(json_data, json_file, indent=4)
 
             seed += 1
             results += imgs

--- a/modules/default_pipeline.py
+++ b/modules/default_pipeline.py
@@ -125,7 +125,10 @@ def build_json(positive_prompt, negative_prompt, steps, switch, width, height, i
         "switch": switch,
         "width": width,
         "height": height,
-        "image_seed": image_seed
+        "image_seed": image_seed,
+        "base_model": modules.path.default_base_model_name,
+        "refiner_model": modules.path.default_refiner_model_name,
+        "loras": modules.path.default_lora_name
     }
     return json_data
 

--- a/modules/default_pipeline.py
+++ b/modules/default_pipeline.py
@@ -128,7 +128,6 @@ def build_json(positive_prompt, negative_prompt, steps, switch, width, height, i
         "image_seed": image_seed,
         "base_model": modules.path.default_base_model_name,
         "refiner_model": modules.path.default_refiner_model_name,
-        "loras": modules.path.default_lora_name
     }
     return json_data
 

--- a/modules/default_pipeline.py
+++ b/modules/default_pipeline.py
@@ -117,6 +117,17 @@ def clean_prompt_cond_caches():
     negative_conditions_refiner_cache = None
     return
 
+def build_json(positive_prompt, negative_prompt, steps, switch, width, height, image_seed):
+    json_data = {
+        "positive_prompt": positive_prompt,
+        "negative_prompt": negative_prompt,
+        "steps": steps,
+        "switch": switch,
+        "width": width,
+        "height": height,
+        "image_seed": image_seed
+    }
+    return json_data
 
 @torch.no_grad()
 def process(positive_prompt, negative_prompt, steps, switch, width, height, image_seed, callback):
@@ -166,5 +177,7 @@ def process(positive_prompt, negative_prompt, steps, switch, width, height, imag
     decoded_latent = core.decode_vae(vae=xl_base_patched.vae, latent_image=sampled_latent)
 
     images = core.image_to_numpy(decoded_latent)
+    json_data = []
+    json_data.append(build_json(positive_prompt, negative_prompt, steps, switch, width, height, image_seed))
 
-    return images
+    return images, json_data


### PR DESCRIPTION
This pull request is about saving the generation information in a json file with the same name as the generated image file. This is believed to address the following requests:

1. [The design policy of Fooocus,](https://github.com/lllyasviel/Fooocus/issues/125) which is to not store anything in the generated image.
2. The opinion of some users who want to check the generation information later.