### PR TITLE
Revert "move text encoder to GPU (#360)"

### DIFF
--- a/fooocus_version.py
+++ b/fooocus_version.py
@@ -1,1 +1,1 @@
-version = '2.0.4'
+version = '2.0.3'

--- a/modules/patch.py
+++ b/modules/patch.py
@@ -70,8 +70,7 @@ def sdxl_encode_adm_patched(self, **kwargs):
 
 
 def text_encoder_device_patched():
-    # Fooocus's style system uses text encoder much more times than comfy so this makes things much faster.
-    return comfy.model_management.get_torch_device()
+    return torch.device("cpu")
 
 
 def patch_all():


### PR DESCRIPTION
This reverts commit 7700276b5013ff6a4ce9776bfe6b6919326654b0.

This seems to influence result quality.