### PR TITLE
Feature: Weights & Biases integration for Fooocus

### DIFF
--- a/modules/private_logger.py
+++ b/modules/private_logger.py
@@ -4,6 +4,13 @@ import modules.path
 from PIL import Image
 from modules.util import generate_temp_filename
 
+IS_WANDB_INSTALLED = False
+try:
+    import wandb
+    IS_WANDB_INSTALLED = True
+except:
+    IS_WANDB_INSTALLED = False
+
 
 def log(img, dic, single_line_number=3):
     date_string, local_temp_filename, only_name = generate_temp_filename(folder=modules.path.temp_outputs_path, extension='png')
@@ -35,3 +42,11 @@ def log(img, dic, single_line_number=3):
     print(f'Image generated with private log at: {html_name}')
 
     return
+
+
+def log_to_wandb(image, configs, table):
+    configs = {cfg[0]: cfg[1] for cfg in configs}
+    image = wandb.Image(Image.fromarray(image))
+    table.add_data(configs["Prompt"], configs["Negative Prompt"], image)
+    wandb.log({"Generated-Images": image})
+    return table

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,28 @@ Or if you want to open a remote port, use
 
     python launch.py --listen
 
+### [Weights & Biases](https://wandb.ai/site) Integration for Fooocus
+
+The Weights & Biases integration with Fooocus automatically adds a History tab to the UI that keeps track of all your generations in a project by syncing it with Weights & Biases. Effortlessly, you can keep track of all of your past generations and your configs, without having to leave the Fooocus UI itself. You can also open up the W&B project and explore individual runs from the UI as well!
+
+Generated images logged into a [W&B Table](https://docs.wandb.ai/guides/tables) with the prompts and negative prompts. Users can also explore the respective Fooocus configs to generate the artwork by using the weave expression `row.run.config["config-name"]` to query them right in the table itself. Generated images are also automatically logged into a W&B media panel that enables us to share with our friends and colleagues in the form of a shareable art gallery.
+
+In order to use the Weights & Biases integration for Fooocus, you need to perform the following command line operations after having installed Fooocus:
+
+```shell
+# Login to your W&B account or create one
+wandb login
+
+# Set your project and entity name
+export WANDB_PROJECT="my-awesome-project"
+export WANDB_ENTITY="my-team-or-username"
+
+# Launch Fooocus
+python launch.py --listen
+```
+
+**Note:** The Weights & Biases integration does not disrupt any of the default functionalities of Fooocus and is only enabled if you have logged into your W&B account and set up your W&B project name and entity name before launcing Fooocus.
+
 ### Mac/Windows(AMD GPUs)
 
 Coming soon ...


### PR DESCRIPTION
Being a user of both Fooocus and [Weights & Biases](https://wandb.ai/site), I decided to prototype an integration of Fooocus with Weights & Biases. The prototype for this integration currently resides in [the development branch of my fork of Fooocus](https://github.com/soumik12345/Fooocus/tree/feat/fooocus-wandb).

## Instructions for using the W&B integration with Fooocus 👇

```bash
# Clone Fooocus (currently it is the development branch of my fork of Fooocus)
git clone https://github.com/soumik12345/fooocus -b feat/fooocus-wandb
cd Fooocus

# Install dependencies for Fooocus
conda env create -f environment.yaml
conda activate fooocus
pip install -r requirements_versions.txt

# Install Weights & Biases
pip install wandb

# Login to your W&B account or create one
wandb login

# Set your project and entity name
export WANDB_PROJECT="my-awesome-project"
export WANDB_ENTITY="my-team-or-username"

# Launch Fooocus
python launch.py --listen
```

## The integration of W&B with Foocus consists of the following features 👇

### Never miss another one of your past generations

The W&B integration with Fooocus automatically adds a **History** tab to the UI that keeps track of all your generations in a project by syncing it with Weights & Biases. Effortlessly, you can keep track of all of your past generations and your configs, without having to leave the Fooocus UI itself. You can also open up the W&B project and explore individual runs from the UI as well!

https://github.com/lllyasviel/Fooocus/assets/19887676/f8c227bf-4fa3-4780-93c7-8b09d53c23e8

### A system of records for all your Artwork

Artworks logged into a [W&B Table](https://docs.wandb.ai/guides/tables) with the prompts and negative prompts. Users can also explore the respective Fooocus configs to generate the artwork by using the weave expression `row.run.config["config-name"]` to query them right in the table itself.

https://github.com/lllyasviel/Fooocus/assets/19887676/3b40b648-d1a9-49d2-91fa-1f5c2c0ee7ed

### A shareable Art Gallery

Artworks are also automatically logged into a W&B media panel that enables us to share with our friends and colleagues in the form of a shareable art gallery.

https://github.com/lllyasviel/Fooocus/assets/19887676/a9c40471-7f4b-4f9e-b215-76761fa77ac6

### Weave your artworks Effortlessly into W&B reports

Share your artistic experiments with your friends and colleagues, convert them into blog posts, or weave them together to tell your own story, using [W&B reports](https://docs.wandb.ai/guides/reports).

https://github.com/lllyasviel/Fooocus/assets/19887676/e2619bfa-1b38-43bb-bb06-1c9c3bb98560

## Note

- Using this integration is meant to be completely optional, if and only if [`wandb`](https://github.com/wandb/wandb) is installed. The integration does not interfere with the intended workflow of Fooocus.
- Weights & Biases is free for personal projects and for academic research with an unlimited number of experiments and projects, unlimited tracked hours, and 100 GB of storage free!