### PR TITLE
Pass additional command line arguments to launch.py through run.bat scripts

### DIFF
--- a/build_launcher.py
+++ b/build_launcher.py
@@ -6,7 +6,7 @@ python_embeded_path = os.path.join(win32_root, 'python_embeded')
 is_win32_standalone_build = os.path.exists(python_embeded_path) and os.path.isdir(python_embeded_path)
 
 win32_cmd = '''
-.\python_embeded\python.exe -s Fooocus\entry_with_update.py {cmds}
+.\python_embeded\python.exe -s Fooocus\entry_with_update.py {cmds} %*
 pause
 '''
 


### PR DESCRIPTION
When launching Foocus it's useful to be able to pass additional arguments to the launch script.

This change adds the the `%*` modifier at the end of the base command string so that we can do something like

```bash
./run.bat --listen
```

instead of modifying the batch file manually.