### PR TITLE
Add option for default performance setting + suffix ordinals with lambda

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -556,7 +556,7 @@ def worker():
             done_steps = current_task_id * steps + step
             outputs.append(['preview', (
                 int(15.0 + 85.0 * float(done_steps) / float(all_steps)),
-                f'Step {step}/{total_steps} in the {current_task_id + 1}-th Sampling',
+                f'Step {step}/{total_steps} in the {(lambda n: "%d-%s" % (n, "tsnrhtdd"[(n // 10 % 10 != 1) * (n % 10 < 4) * n % 10::4]))(current_task_id + 1)} Sampling',
                 y)])
 
         for current_task_id, task in enumerate(tasks):

--- a/modules/path.py
+++ b/modules/path.py
@@ -153,6 +153,11 @@ default_image_number = get_config_item_or_set_default(
     default_value=2,
     validator=lambda x: isinstance(x, int) and x >= 1 and x <= 32
 )
+default_performance_selection = get_config_item_or_set_default(
+    key='default_performance_selection',
+    default_value='Speed',
+    validator=lambda x: x in ['Speed', 'Quality']
+)
 checkpoint_downloads = get_config_item_or_set_default(
     key='checkpoint_downloads',
     default_value={

--- a/webui.py
+++ b/webui.py
@@ -195,7 +195,7 @@ with shared.gradio_root:
 
         with gr.Column(scale=1, visible=modules.path.default_advanced_checkbox) as advanced_column:
             with gr.Tab(label='Setting'):
-                performance_selection = gr.Radio(label='Performance', choices=['Speed', 'Quality'], value='Speed')
+                performance_selection = gr.Radio(label='Performance', choices=['Speed', 'Quality'], value=modules.path.default_performance_selection)
                 aspect_ratios_selection = gr.Radio(label='Aspect Ratios', choices=modules.path.available_aspect_ratios,
                                                    value=modules.path.default_aspect_ratio, info='width × height')
                 image_number = gr.Slider(label='Image Number', minimum=1, maximum=32, step=1, value=modules.path.default_image_number)


### PR DESCRIPTION
- Adds the ability to set a default performance setting in user_path_config rather than always defaulting to 'Speed'
- When doing multiple generations: Rather than always suffixing the number with "-th" (e.g., 1-th, 2-th...), now uses a lambda to determine the correct suffix to apply to the number (e.g., 1-st, 2-nd, 3-rd...)

I really quite enjoy this software and would be thrilled should you accept my contribution!