### PR TITLE
disable log via config

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -268,6 +268,11 @@ default_overwrite_switch = get_config_item_or_set_default(
     default_value=-1,
     validator=lambda x: isinstance(x, int)
 )
+default_disable_log = get_config_item_or_set_default(
+    key='default_disable_log',
+    default_value=False,
+    validator=lambda x: isinstance(x, bool)
+)
 
 
 def add_ratio(x):

--- a/modules/private_logger.py
+++ b/modules/private_logger.py
@@ -16,6 +16,9 @@ def get_current_html_path():
 
 
 def log(img, dic, single_line_number=3):
+    if modules.config.default_disable_log:
+        return
+
     date_string, local_temp_filename, only_name = generate_temp_filename(folder=modules.config.path_outputs, extension='png')
     os.makedirs(os.path.dirname(local_temp_filename), exist_ok=True)
     Image.fromarray(img).save(local_temp_filename)

--- a/webui.py
+++ b/webui.py
@@ -222,7 +222,8 @@ with shared.gradio_root:
 
                 seed_random.change(random_checked, inputs=[seed_random], outputs=[image_seed], queue=False)
 
-                gr.HTML(f'<a href="/file={get_current_html_path()}" target="_blank">\U0001F4DA History Log</a>')
+                if not modules.config.default_disable_log:
+                    gr.HTML(f'<a href="/file={get_current_html_path()}" target="_blank">\U0001F4DA History Log</a>')
 
             with gr.Tab(label='Style'):
                 style_sorter.try_load_sorted_styles(


### PR DESCRIPTION
also hides the "History Log" link if set to true

sometimes you don't want to save all created images OR one even didn't know they were all saved in the first place, so this config option allows disabling the logging altogether