### PR TITLE
Fix canvas tooltip position

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -29,8 +29,8 @@
 
 .canvas-tooltip-info {
   position: absolute;
-  top: 10px;
-  left: 10px;
+  top: 28px;
+  left: 2px;
   cursor: help;
   background-color: rgba(0, 0, 0, 0.3);
   width: 20px;


### PR DESCRIPTION

Hi, Fooocus is a very cool tool!

I've little improved the position of this tooltip.
Is this fix acceptable to this project?

Before:

<img width="1423" alt="before_2023-11-17 18 43 16" src="https://github.com/lllyasviel/Fooocus/assets/8216064/36e41622-d210-49ee-8b27-38ee4ff078ea">


After:

<img width="1441" alt="after_2023-11-18 6 53 52" src="https://github.com/lllyasviel/Fooocus/assets/8216064/87bf9bd7-db4a-40b9-a3b9-f057287e9233">

Thank you!