### PR TITLE
fix: typo in error handling

### DIFF
--- a/backend/headless/fcbh/samplers.py
+++ b/backend/headless/fcbh/samplers.py
@@ -634,7 +634,7 @@ def calculate_sigmas_scheduler(model, scheduler_name, steps):
     elif scheduler_name == "sgm_uniform":
         sigmas = normal_scheduler(model, steps, sgm=True)
     else:
-        print("error invalid scheduler", self.scheduler)
+        raise ValueError(f"error invalid scheduler {scheduler_name}")
     return sigmas
 
 def sampler_object(name):


### PR DESCRIPTION
`self` does not exist in the scope of `calculate_sigmas_scheduler` function, and it raises a wrong error.