### PR TITLE
Fix Broken Links

### DIFF
--- a/backend/headless/fcbh_extras/chainner_models/architecture/HAT.py
+++ b/backend/headless/fcbh_extras/chainner_models/architecture/HAT.py
@@ -30,7 +30,7 @@ def drop_path(x, drop_prob: float = 0.0, training: bool = False):
 
 class DropPath(nn.Module):
     """Drop paths (Stochastic Depth) per sample  (when applied in main path of residual blocks).
-    From: https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/layers/drop.py
+    From: https://github.com/huggingface/pytorch-image-models/blob/4d0737d5fa9674e64cb9210c688d2dd168dbb448/timm/layers/drop.py
     """
 
     def __init__(self, drop_prob=None):

--- a/backend/headless/fcbh_extras/chainner_models/architecture/HAT.py
+++ b/backend/headless/fcbh_extras/chainner_models/architecture/HAT.py
@@ -14,7 +14,7 @@ from .timm.weight_init import trunc_normal_
 
 def drop_path(x, drop_prob: float = 0.0, training: bool = False):
     """Drop paths (Stochastic Depth) per sample (when applied in main path of residual blocks).
-    From: https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/layers/drop.py
+    From: https://github.com/huggingface/pytorch-image-models/blob/4d0737d5fa9674e64cb9210c688d2dd168dbb448/timm/layers/drop.py
     """
     if drop_prob == 0.0 or not training:
         return x

--- a/backend/headless/fcbh_extras/chainner_models/architecture/RRDB.py
+++ b/backend/headless/fcbh_extras/chainner_models/architecture/RRDB.py
@@ -13,7 +13,7 @@ import torch.nn.functional as F
 from . import block as B
 
 
-# Borrowed from https://github.com/rlaphoenix/VSGAN/blob/master/vsgan/archs/ESRGAN.py
+# Borrowed from https://github.com/rlaphoenix/VSGAN/blob/master/vsgan/archs/esrgan.py
 # Which enhanced stuff that was already here
 class RRDBNet(nn.Module):
     def __init__(

--- a/backend/headless/fcbh_extras/nodes_canny.py
+++ b/backend/headless/fcbh_extras/nodes_canny.py
@@ -174,7 +174,7 @@ def canny(
         - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
         - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
+       See a working example `here <https://kornia.readthedocs.io/en/latest/
        canny.html>`__.
     Example:
         >>> input = torch.rand(5, 3, 4, 4)

--- a/backend/headless/fcbh_extras/nodes_canny.py
+++ b/backend/headless/fcbh_extras/nodes_canny.py
@@ -76,7 +76,7 @@ def spatial_gradient(input, normalized: bool = True):
     Return:
         the derivatives of the input feature map. with shape :math:`(B, C, 2, H, W)`.
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
+       See a working example `here <https://kornia.readthedocs.io/en/latest/
        filtering_edges.html>`__.
     Examples:
         >>> input = torch.rand(1, 3, 4, 4)

--- a/backend/headless/fcbh_extras/nodes_canny.py
+++ b/backend/headless/fcbh_extras/nodes_canny.py
@@ -118,7 +118,7 @@ def rgb_to_grayscale(image, rgb_weights = None):
         grayscale version of the image with shape :math:`(*,1,H,W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
+       See a working example `here <https://kornia.readthedocs.io/en/latest/
        color_conversions.html>`__.
 
     Example:


### PR DESCRIPTION
There are multiple broken links in this project. Here are the ones I have fixed.

https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/layers/drop.py --> https://github.com/huggingface/pytorch-image-models/blob/4d0737d5fa9674e64cb9210c688d2dd168dbb448/timm/layers/drop.py

https://github.com/rlaphoenix/VSGAN/blob/master/vsgan/archs/ESRGAN.py --> https://github.com/rlaphoenix/VSGAN/blob/master/vsgan/archs/esrgan.py

https://kornia-tutorials.readthedocs.io/en/latest/ -->
https://kornia.readthedocs.io/en/latest/

These broken links where found with [link-inspector](https://github.com/justindhillon/link-inspector)
Signed off: [justin.singh.dhillon@gmail.com](mailto:justin.singh.dhillon@gmail.com)