### PR TITLE
add prompt translation

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -41,6 +41,7 @@ def worker():
     from modules.util import remove_empty_str, HWC3, resize_image, \
         get_image_shape_ceil, set_image_shape_ceil, get_shape_ceil, resample_image
     from modules.upscaler import perform_upscale
+    from modules.translator import translate2en
 
     try:
         async_gradio_app = shared.gradio_root
@@ -120,6 +121,7 @@ def worker():
 
         prompt = args.pop()
         negative_prompt = args.pop()
+        translate_prompts = args.pop()
         style_selections = args.pop()
         performance_selection = args.pop()
         aspect_ratios_selection = args.pop()
@@ -194,6 +196,10 @@ def worker():
             modules.patch.negative_adm_scale = advanced_parameters.adm_scaler_negative = 1.0
             modules.patch.adm_scaler_end = advanced_parameters.adm_scaler_end = 0.0
             steps = 8
+
+        if translate_prompts:
+            prompt = translate2en(prompt, 'prompt')
+            negative_prompt = translate2en(negative_prompt, 'negative prompt')
 
         modules.patch.adaptive_cfg = advanced_parameters.adaptive_cfg
         print(f'[Parameters] Adaptive CFG = {modules.patch.adaptive_cfg}')

--- a/modules/translator.py
+++ b/modules/translator.py
@@ -8,8 +8,8 @@ def translate2en(text, element):
 
     try:
         result = translators.translate_text(text,to_language='en')
-        print(f'Translated {element}: {result}')
+        print(f'[Parameters] Translated {element}: {result}')
         return result
     except Exception as e:
-        print(f'Error during translation of {element}: {e}')
+        print(f'[Parameters] Error during translation of {element}: {e}')
         return text

--- a/modules/translator.py
+++ b/modules/translator.py
@@ -1,0 +1,15 @@
+import translators
+from functools import lru_cache
+
+@lru_cache(maxsize=32, typed=False)
+def translate2en(text, element):
+    if not text:
+        return text
+
+    try:
+        result = translators.translate_text(text,to_language='en')
+        print(f'Translated {element}: {result}')
+        return result
+    except Exception as e:
+        print(f'Error during translation of {element}: {e}')
+        return text

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -15,3 +15,4 @@ gradio==3.41.2
 pygit2==1.12.2
 opencv-contrib-python==4.8.0.74
 httpx==0.24.1
+translators=5.6.0

--- a/webui.py
+++ b/webui.py
@@ -14,26 +14,12 @@ import modules.advanced_parameters as advanced_parameters
 import modules.style_sorter as style_sorter
 import args_manager
 import copy
-import translators
 
 from modules.sdxl_styles import legal_style_names
 from modules.private_logger import get_current_html_path
 from modules.ui_gradio_extensions import reload_javascript
 from modules.auth import auth_enabled, check_auth
-from functools import lru_cache
-
-@lru_cache(maxsize=32, typed=False)
-def translate2en(text, element):
-    if not text:
-        return text
-
-    try:
-        result = translators.translate_text(text,to_language='en')
-        print(f'Translated {element}: {result}')
-        return result
-    except Exception as e:
-        print(f'Error during translation of {element}: {e}')
-        return text
+from modules.translator import translate2en
 
 def generate_clicked(*args):
     import fcbh.model_management as model_management
@@ -47,6 +33,7 @@ def generate_clicked(*args):
 
     args = list(args)
 
+    # translate prompts
     if args[2]:
         args[0] = translate2en(args[0], 'prompt')
         args[1] = translate2en(args[1], 'negative prompt')

--- a/webui.py
+++ b/webui.py
@@ -19,7 +19,6 @@ from modules.sdxl_styles import legal_style_names
 from modules.private_logger import get_current_html_path
 from modules.ui_gradio_extensions import reload_javascript
 from modules.auth import auth_enabled, check_auth
-from modules.translator import translate2en
 
 def generate_clicked(*args):
     import fcbh.model_management as model_management
@@ -30,17 +29,7 @@ def generate_clicked(*args):
     # outputs=[progress_html, progress_window, progress_gallery, gallery]
 
     execution_start_time = time.perf_counter()
-
-    args = list(args)
-
-    # translate prompts
-    if args[2]:
-        args[0] = translate2en(args[0], 'prompt')
-        args[1] = translate2en(args[1], 'negative prompt')
-    # remove translate_prompts from args
-    args.pop(2)
-
-    task = worker.AsyncTask(args=args)
+    task = worker.AsyncTask(args=list(args))
     finished = False
 
     yield gr.update(visible=True, value=modules.html.make_progress_html(1, 'Waiting for task to start ...')), \


### PR DESCRIPTION
Implements https://github.com/lllyasviel/Fooocus/issues/983

It's currently not possible to use the latest version of https://pypi.org/project/translators/ (5.8.9) without updating tqdm or using the latest compatible version (5.6.0), so i updated tqdm to 4.65.0.
As of the changelog https://tqdm.github.io/releases/ there are no breaking changes, but it would also be sufficient to use translators==5.6.0.

```
The conflict is caused by:
    The user requested tqdm==4.64.1
    transformers 4.30.2 depends on tqdm>=4.27
    pytorch-lightning 1.9.4 depends on tqdm>=4.57.0
    translators 5.8.9 depends on tqdm>=4.65.0
```

