### PR TITLE
Fix ordinal numeral suffix

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -711,9 +711,11 @@ def worker():
 
         def callback(step, x0, x, total_steps, y):
             done_steps = current_task_id * steps + step
+            suffix = (current_task_id + 1) // 10
+            suffix = "st" if suffix == 1 else "nd" if suffix == 2 else "rd" if suffix == 3 else "th"
             async_task.yields.append(['preview', (
                 int(15.0 + 85.0 * float(done_steps) / float(all_steps)),
-                f'Step {step}/{total_steps} in the {current_task_id + 1}-th Sampling',
+                f'Step {step}/{total_steps} in the {current_task_id + 1}-{suffix} sampling',
                 y)])
 
         for current_task_id, task in enumerate(tasks):

--- a/readme.md
+++ b/readme.md
@@ -297,7 +297,7 @@ Consider twice before you really change the config. If you find yourself breakin
 
 A safter way is just to try "run_anime.bat" or "run_realistic.bat" - they should be already good enough for different tasks.
 
-Note that `user_path_config.txt` is deprecated and will be removed soon.
+~Note that `user_path_config.txt` is deprecated and will be removed soon.~ (Edit: it is already removed.)
 
 ## Advanced Features
 

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ In the first time you launch the software, it will automatically download models
 1. It will download [default models](#models) to the folder "Fooocus\models\checkpoints" given different presets. You can download them in advance if you do not want automatic download.
 2. Note that if you use inpaint, at the first time you inpaint an image, it will download [Fooocus's own inpaint control model from here](https://huggingface.co/lllyasviel/fooocus_inpaint/resolve/main/inpaint_v26.fooocus.patch) as the file "Fooocus\models\inpaint\inpaint_v26.fooocus.patch" (the size of this file is 1.28GB).
 
-After Fooocus 2.1.60, you will also have `run_anime.bat` and `run_realistic.bat`. They are different model presets (and requires different models, but thet will be automatically downloaded). [Check here for more details](https://github.com/lllyasviel/Fooocus/discussions/679).
+After Fooocus 2.1.60, you will also have `run_anime.bat` and `run_realistic.bat`. They are different model presets (and requires different models, but they will be automatically downloaded). [Check here for more details](https://github.com/lllyasviel/Fooocus/discussions/679).
 
 ![image](https://github.com/lllyasviel/Fooocus/assets/19834515/d386f817-4bd7-490c-ad89-c1e228c23447)
 


### PR DESCRIPTION
Fixes a small english mistake relating to ordinal numeral suffixes.
Before:
![before](https://github.com/lllyasviel/Fooocus/assets/58981929/b075c60b-afd4-43bd-8d4e-3c03b8f0be3f)
After:
![after](https://github.com/lllyasviel/Fooocus/assets/58981929/a43ecd6d-6221-46ec-8acd-d7adb977ff57)

