### PR TITLE
Update args_manager.py to disable launching default browser at startup

### DIFF
--- a/args_manager.py
+++ b/args_manager.py
@@ -18,6 +18,8 @@ fcbh_cli.parser.add_argument("--enable-smart-memory", action="store_true",
 fcbh_cli.parser.add_argument("--theme", type=str, help="launches the UI with light or dark theme", default=None)
 fcbh_cli.parser.add_argument("--disable-image-log", action='store_true',
                              help="Prevent writing images and logs to hard drive.")
+fcbh_cli.parser.add_argument("--disable-browser", action="store_false", dest="auto_launch",
+                    help="Disable launching the default browser at startup.")
 
 fcbh_cli.parser.set_defaults(
     disable_cuda_malloc=True,


### PR DESCRIPTION
When launching using ```python entry_with_update.py --listen```, it automatically starts a default browser. But if need to run it in headless mode without launching default browser added a new flag "--disable-browser" which changes the value of auto_launch to False. This is done so that can use without launching the browser when starting it in headless mode on terminal.