### PR TITLE
Updates readme to use consistent python3 version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,17 +150,17 @@ Your Linux needs to have **Python 3.10** installed, and lets say your Python can
     cd Fooocus
     python3 -m venv fooocus_env
     source fooocus_env/bin/activate
-    pip install -r requirements_versions.txt
+    pip3 install -r requirements_versions.txt
 
 See the above sections for model downloads. You can launch the software with:
 
     source fooocus_env/bin/activate
-    python entry_with_update.py
+    python3 entry_with_update.py
 
 Or if you want to open a remote port, use
 
     source fooocus_env/bin/activate
-    python entry_with_update.py --listen
+    python3 entry_with_update.py --listen
 
 Use `python entry_with_update.py --preset anime` or `python entry_with_update.py --preset realistic` for Fooocus Anime/Realistic Edition.
 


### PR DESCRIPTION
The same python version should be consistently used. Right now, we could be using a different python version to set up the venv but another python to install requirements and running the scripts.

While this is an uncommon scenario, but still might be relevant for a lot of scenarios. 

Breakdown of the issue:
1. Virtual Env was being created using `python3` but all the subsequent commands utilize the `python`
2. In most cases, `python` and `python3` could be referencing to different python versions.
3. We should be using the same python command we created the venv with i.e. `python3`
