### PR TITLE
Fix default Transformers cache directory not writable bug #1143

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -61,8 +61,11 @@ def prepare_environment():
         print("Windows detected. Assigning cache directory to Transformers in AppData\Local.")
         transformers_cache_directory = os.path.join(os.getenv('LOCALAPPDATA'), 'transformers_cache')
         if not os.path.exists(transformers_cache_directory):
-            os.mkdir(transformers_cache_directory)
-            print(f"First launch. Directory '{transformers_cache_directory}' created successfully.")
+            try:
+                os.mkdir(transformers_cache_directory)
+                print(f"First launch. Directory '{transformers_cache_directory}' created successfully.")
+            except OSError as e:
+                print(f"Error creating directory '{transformers_cache_directory}': {e}")
         else:
             print(f"Directory '{transformers_cache_directory}' already exists.")
         os.environ['TRANSFORMERS_CACHE'] = transformers_cache_directory


### PR DESCRIPTION
This PR fixes  #1143. 

Added assignment of cache directory for Transformers to a writable location in accordance with Windows use of AppData for cache. 
Code added in ``prepare_environment``: 
```python
    if platform.system() == "Windows":
        print("Windows detected. Assigning cache directory to Transformers in AppData\Local.")
        transformers_cache_directory = os.path.join(os.getenv('LOCALAPPDATA'), 'transformers_cache')
        if not os.path.exists(transformers_cache_directory):
            try:
                os.mkdir(transformers_cache_directory)
                print(f"First launch. Directory '{transformers_cache_directory}' created successfully.")
            except OSError as e:
                print(f"Error creating directory '{transformers_cache_directory}': {e}")
        else:
            print(f"Directory '{transformers_cache_directory}' already exists.")
        os.environ['TRANSFORMERS_CACHE'] = transformers_cache_directory
        print("Environment variable assigned.")
        del transformers_cache_directory

    else:
        print("Windows not detected. Assignment of Transformers cache directory not necessary.")
```

Prior to this change the program would throw error: ``There was a problem when trying to write in your cache folder (C:\Users\USERNAME/.cache\huggingface\hub). You should set the environment variable TRANSFORMERS_CACHE to a writable directory.`` 
Further information in "Default huggingface transformers cache directory may not be writable on Windows #1143"