### PR TITLE
Update anime preset to latest bluepencil 3.1.0 release

### DIFF
--- a/presets/anime.json
+++ b/presets/anime.json
@@ -1,5 +1,5 @@
 {
-    "default_model": "blue_pencil-XL-v2.0.0.safetensors",
+    "default_model": "blue_pencil-XL-v3.1.0.safetensors",
     "default_refiner": "DreamShaper_8_pruned.safetensors",
     "default_refiner_switch": 0.667,
     "default_loras": [
@@ -41,7 +41,7 @@
     ],
     "default_aspect_ratio": "896*1152",
     "checkpoint_downloads": {
-        "blue_pencil-XL-v2.0.0.safetensors": "https://huggingface.co/bluepen5805/blue_pencil-XL/raw/main/blue_pencil-XL-v2.0.0.safetensors",
+        "blue_pencil-XL-v3.1.0.safetensors": "https://huggingface.co/bluepen5805/blue_pencil-XL/raw/main/blue_pencil-XL-v3.1.0.safetensors",
         "DreamShaper_8_pruned.safetensors": "https://huggingface.co/lllyasviel/fav_models/resolve/main/fav/DreamShaper_8_pruned.safetensors"
     },
     "embeddings_downloads": {

--- a/presets/anime.json
+++ b/presets/anime.json
@@ -41,7 +41,7 @@
     ],
     "default_aspect_ratio": "896*1152",
     "checkpoint_downloads": {
-        "bluePencilXL_v050.safetensors": "https://huggingface.co/bluepen5805/blue_pencil-XL/raw/main/blue_pencil-XL-v2.0.0.safetensors",
+        "blue_pencil-XL-v2.0.0.safetensors": "https://huggingface.co/bluepen5805/blue_pencil-XL/raw/main/blue_pencil-XL-v2.0.0.safetensors",
         "DreamShaper_8_pruned.safetensors": "https://huggingface.co/lllyasviel/fav_models/resolve/main/fav/DreamShaper_8_pruned.safetensors"
     },
     "embeddings_downloads": {

--- a/presets/anime.json
+++ b/presets/anime.json
@@ -1,5 +1,5 @@
 {
-    "default_model": "bluePencilXL_v050.safetensors",
+    "default_model": "blue_pencil-XL-v2.0.0.safetensors",
     "default_refiner": "DreamShaper_8_pruned.safetensors",
     "default_refiner_switch": 0.667,
     "default_loras": [
@@ -41,7 +41,7 @@
     ],
     "default_aspect_ratio": "896*1152",
     "checkpoint_downloads": {
-        "bluePencilXL_v050.safetensors": "https://huggingface.co/lllyasviel/fav_models/resolve/main/fav/bluePencilXL_v050.safetensors",
+        "bluePencilXL_v050.safetensors": "https://huggingface.co/bluepen5805/blue_pencil-XL/raw/main/blue_pencil-XL-v2.0.0.safetensors",
         "DreamShaper_8_pruned.safetensors": "https://huggingface.co/lllyasviel/fav_models/resolve/main/fav/DreamShaper_8_pruned.safetensors"
     },
     "embeddings_downloads": {


### PR DESCRIPTION
Update the bluepencil-XL to latest version 2.0.0 which is released on 1st December 2023. This model is the latest release from bluepen5805. Results are also good for sketch and pencil.