### PR TITLE
Prevent BatchedBrownianTree crash on startup on AMD

### DIFF
--- a/backend/headless/fcbh/k_diffusion/sampling.py
+++ b/backend/headless/fcbh/k_diffusion/sampling.py
@@ -70,6 +70,8 @@ class BatchedBrownianTree:
             self.cpu_tree = kwargs.pop("cpu")
         t0, t1, self.sign = self.sort(t0, t1)
         w0 = kwargs.get('w0', torch.zeros_like(x))
+        if w0.device.type == "privateuseone":
+            self.cpu_tree = True
         if seed is None:
             seed = torch.randint(0, 2 ** 63 - 1, []).item()
         self.batched = True


### PR DESCRIPTION
This solves a common issue reported in #1263, #1185, #1091 and others. A solution is to enable `cpu_tree` within the class `BatchedBrownianTree` for AMD products (or at least `privateuseone` devices, as I'm not sure what kind of other hardware is also of type `privateuseone`).