### PR TITLE
Fix generate shortcut bug and add interrupt shortcut

### DIFF
--- a/javascript/script.js
+++ b/javascript/script.js
@@ -133,12 +133,14 @@ document.addEventListener('keydown', function(e) {
         if (generateButton) {
             generateButton.click();
             e.preventDefault();
+            return;
         }
 
         const stopButton = gradioApp().querySelector('button:not(.hidden)[id=stop_button]')
         if(stopButton) {
             stopButton.click();
             e.preventDefault();
+            return;
         }
     }
 });

--- a/javascript/script.js
+++ b/javascript/script.js
@@ -125,18 +125,21 @@ document.addEventListener("DOMContentLoaded", function() {
  * Add a ctrl+enter as a shortcut to start a generation
  */
 document.addEventListener('keydown', function(e) {
-    var handled = false;
-    if (e.key !== undefined) {
-        if ((e.key == "Enter" && (e.metaKey || e.ctrlKey || e.altKey))) handled = true;
-    } else if (e.keyCode !== undefined) {
-        if ((e.keyCode == 13 && (e.metaKey || e.ctrlKey || e.altKey))) handled = true;
-    }
-    if (handled) {
-        var button = gradioApp().querySelector('button[id=generate_button]');
-        if (button) {
-            button.click();
+    const isModifierKey = (e.metaKey || e.ctrlKey || e.altKey);
+    const isEnterKey = (e.key == "Enter" || e.keyCode == 13);
+
+    if(isModifierKey && isEnterKey) {
+        const generateButton = gradioApp().querySelector('button:not(.hidden)[id=generate_button]');
+        if (generateButton) {
+            generateButton.click();
+            e.preventDefault();
         }
-        e.preventDefault();
+
+        const stopButton = gradioApp().querySelector('button:not(.hidden)[id=stop_button]')
+        if(stopButton) {
+            stopButton.click();
+            e.preventDefault();
+        }
     }
 });
 


### PR DESCRIPTION
I noticed that the shortcut for a quick start with ctrl+enter would also cause an issue if hit again while the gernation had already started. It would click the (now hidden) generate button again in the background. One the first generation finishes the second would start off but the UI would not recognise it. 

This solves that by only clicking the button when visible as well as making the ctrl+enter shortcut stop the current generation allowing people to update their prompts faster if they dont like the current direction the previews are showing, or if they made a mistake. 