### PR TITLE
fix zooming on large-width images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -94,6 +94,10 @@
   overflow:inherit !important;
 }
 
+.gradio-container{
+  overflow: visible;
+}
+
 /* fullpage image viewer */
 
 #lightboxModal{


### PR DESCRIPTION
Hi, glad to see that my work is present in this great interface.

I saw the issue #1427  and fixed the problem.
Also, if you agree, I can clean up `zoom.js` of unnecessary functions left over from auto1111.

![image](https://github.com/lllyasviel/Fooocus/assets/22278673/55be3e6f-27d9-43cf-9ec1-d1f87e67b66f)
