### PR TITLE
Sort Checkpoints and LoRAs alphabetically

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -288,8 +288,8 @@ with shared.gradio_root:
             with gr.Tab(label='Model'):
                 with gr.Group():
                     with gr.Row():
-                        base_model = gr.Dropdown(label='Base Model (SDXL only)', choices=modules.config.model_filenames, value=modules.config.default_base_model_name, show_label=True)
-                        refiner_model = gr.Dropdown(label='Refiner (SDXL or SD 1.5)', choices=['None'] + modules.config.model_filenames, value=modules.config.default_refiner_model_name, show_label=True)
+                        base_model = gr.Dropdown(label='Base Model (SDXL only)', choices=sorted(modules.config.model_filenames), value=modules.config.default_base_model_name, show_label=True)
+                        refiner_model = gr.Dropdown(label='Refiner (SDXL or SD 1.5)', choices=['None'] + sorted(modules.config.model_filenames), value=modules.config.default_refiner_model_name, show_label=True)
 
                     refiner_switch = gr.Slider(label='Refiner Switch At', minimum=0.1, maximum=1.0, step=0.0001,
                                                info='Use 0.4 for SD1.5 realistic models; '
@@ -308,7 +308,7 @@ with shared.gradio_root:
                     for i, (n, v) in enumerate(modules.config.default_loras):
                         with gr.Row():
                             lora_model = gr.Dropdown(label=f'LoRA {i + 1}',
-                                                     choices=['None'] + modules.config.lora_filenames, value=n)
+                                                     choices=['None'] + sorted(modules.config.lora_filenames), value=n)
                             lora_weight = gr.Slider(label='Weight', minimum=-2, maximum=2, step=0.01, value=v,
                                                     elem_classes='lora_weight')
                             lora_ctrls += [lora_model, lora_weight]
@@ -445,9 +445,9 @@ with shared.gradio_root:
                 def model_refresh_clicked():
                     modules.config.update_all_model_names()
                     results = []
-                    results += [gr.update(choices=modules.config.model_filenames), gr.update(choices=['None'] + modules.config.model_filenames)]
+                    results += [gr.update(choices=sorted(modules.config.model_filenames)), gr.update(choices=['None'] + sorted(modules.config.model_filenames))]
                     for i in range(5):
-                        results += [gr.update(choices=['None'] + modules.config.lora_filenames), gr.update()]
+                        results += [gr.update(choices=['None'] + sorted(modules.config.lora_filenames)), gr.update()]
                     return results
 
                 model_refresh.click(model_refresh_clicked, [], [base_model, refiner_model] + lora_ctrls,


### PR DESCRIPTION
This simple PR fixes the right menu's "Model" tab to ensure the Checkpoints and Loras are always sorted alphabetically.
Both at startup and after clicking "Refresh All Files" button.