### PR TITLE
Update readme.md, mention Python 3.11 support, fix a typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -149,7 +149,7 @@ Use `python entry_with_update.py --preset anime` or `python entry_with_update.py
 
 ### Linux (Using Python Venv)
 
-Your Linux needs to have **Python 3.10** installed, and lets say your Python can be called with command **python3** with your venv system working, you can
+Your Linux needs to have at least **Python 3.10** installed (3.11 works as well), and lets say your Python can be called with command **python3** with your venv system working, you can
 
     git clone https://github.com/lllyasviel/Fooocus.git
     cd Fooocus
@@ -171,7 +171,7 @@ Use `python entry_with_update.py --preset anime` or `python entry_with_update.py
 
 ### Linux (Using native system Python)
 
-If you know what you are doing, and your Linux already has **Python 3.10** installed, and your Python can be called with command **python3** (and Pip with **pip3**), you can
+If you know what you are doing, and your Linux already has at least **Python 3.10** installed (3.11 works as well), and your Python can be called with command **python3** (and Pip with **pip3**), you can
 
     git clone https://github.com/lllyasviel/Fooocus.git
     cd Fooocus
@@ -200,7 +200,7 @@ AMD is not intensively tested, however. The AMD support is in beta.
 
 Use `python entry_with_update.py --preset anime` or `python entry_with_update.py --preset realistic` for Fooocus Anime/Realistic Edition.
 
-### Windows(AMD GPUs)
+### Windows (AMD GPUs)
 
 Note that the [minimal requirement](#minimal-requirement) for different platforms is different.
 


### PR DESCRIPTION
This PR mentions Python 3.11 support aside from 3.10 (tested and works perfectly on Debian-based system) as well as fixes a single typo.