### PR TITLE
add workaround for changing prompt while generating

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -525,7 +525,7 @@ with shared.gradio_root:
                 loaded_json = None
 
             if loaded_json is None:
-                return gr.update(), gr.update(visible=True), gr.update(visible=False)
+                return gr.update(), gr.update(), gr.update(visible=False)
 
             return json.dumps(loaded_json), gr.update(visible=False), gr.update(visible=True)
 
@@ -557,11 +557,11 @@ with shared.gradio_root:
             load_parameter_button
         ] + lora_ctrls, queue=False, show_progress=False)
 
-        generate_button.click(lambda: (gr.update(visible=True, interactive=True), gr.update(visible=True, interactive=True), gr.update(visible=False), []), outputs=[stop_button, skip_button, generate_button, gallery]) \
+        generate_button.click(lambda: (gr.update(visible=True, interactive=True), gr.update(visible=True, interactive=True), gr.update(visible=False, interactive=False), []), outputs=[stop_button, skip_button, generate_button, gallery]) \
             .then(fn=refresh_seed, inputs=[seed_random, image_seed], outputs=image_seed) \
             .then(advanced_parameters.set_all_advanced_parameters, inputs=adps) \
             .then(fn=generate_clicked, inputs=ctrls, outputs=[progress_html, progress_window, progress_gallery, gallery]) \
-            .then(lambda: (gr.update(visible=True), gr.update(visible=False), gr.update(visible=False)), outputs=[generate_button, stop_button, skip_button]) \
+            .then(lambda: (gr.update(visible=True, interactive=True), gr.update(visible=False), gr.update(visible=False)), outputs=[generate_button, stop_button, skip_button]) \
             .then(fn=lambda: None, _js='playNotification').then(fn=lambda: None, _js='refresh_grid_delayed')
 
         for notification_file in ['notification.ogg', 'notification.mp3']:


### PR DESCRIPTION
When changing the prompt during generation currently the generate_button or load_parameter_button is displayed.

initial generate_button click:
![Screenshot 2023-12-24 150827](https://github.com/lllyasviel/Fooocus/assets/9307310/f8e4faaa-dd88-49f2-ad95-847eeceefe70)

change prompt:
![Screenshot 2023-12-24 150833](https://github.com/lllyasviel/Fooocus/assets/9307310/66789be5-42f7-4d80-a821-47a47d454565)

This PR fixes this issue and does ...
- not display the generate_button on prompt changes during generation
- display the generate_button as non-interactive after clicking load_parameter_button during generation
![Screenshot 2023-12-24 155243](https://github.com/lllyasviel/Fooocus/assets/9307310/91ed873d-238d-432f-8c6e-bf856b85ecce)
![Screenshot 2023-12-24 154426](https://github.com/lllyasviel/Fooocus/assets/9307310/9b5959e8-68f9-40df-bed3-fb5a6f84240c)