### PR TITLE
Add preset for SDXL Turbo (model DreamShaperXL_Turbo)

### DIFF
--- a/presets/turbo.json
+++ b/presets/turbo.json
@@ -1,0 +1,46 @@
+{
+    "default_model": "DreamShaperXL_Turbo_dpmppSdeKarras_half_pruned_6.safetensors",
+    "default_refiner": "None",
+    "default_refiner_switch": 0.5,
+    "default_loras": [
+        [
+            "None",
+            1.0
+        ],
+        [
+            "None",
+            1.0
+        ],
+        [
+            "None",
+            1.0
+        ],
+        [
+            "None",
+            1.0
+        ],
+        [
+            "None",
+            1.0
+        ]
+    ],
+    "default_cfg_scale": 2.0,
+    "default_sample_sharpness": 3.0,
+    "default_sampler": "dpmpp_sde",
+    "default_scheduler": "karras",
+    "default_performance": "Speed",
+    "default_prompt": "",
+    "default_prompt_negative": "",
+    "default_styles": [
+        "Fooocus V2",
+        "Fooocus Enhance",
+        "Fooocus Sharp"
+    ],
+    "default_aspect_ratio": "1024*1024",
+    "default_overwrite_step": 6,
+    "checkpoint_downloads": {
+        "DreamShaperXL_Turbo_dpmppSdeKarras_half_pruned_6.safetensors": "https://huggingface.co/Lykon/dreamshaper-xl-turbo/resolve/main/DreamShaperXL_Turbo_dpmppSdeKarras_half_pruned_6.safetensors"
+    },
+    "embeddings_downloads": {},
+    "lora_downloads": {}
+}


### PR DESCRIPTION
implements https://github.com/lllyasviel/Fooocus/discussions/1060

references
- https://mindrenders.com/sdxl-turbo-fooocus/
- https://huggingface.co/Lykon/dreamshaper-xl-turbo

What's wondering me is that the list "possible_preset_keys" (config.py) isn't used when loading presets, see https://github.com/lllyasviel/Fooocus/blob/main/modules/config.py#L82-L95, `config_dict.update(json.load(json_file))`.

In this case the behaviour good, so one can simply add default_override_step to the preset and it's working perfectly fine.
Please let me know if you'd rather also have the key default_override_step  in possible_preset_keys. Thanks!

