### PR TITLE
Allow users specify number of threads when running on CPU via the extension to --always-cpu arg

### DIFF
--- a/ldm_patched/modules/args_parser.py
+++ b/ldm_patched/modules/args_parser.py
@@ -98,7 +98,7 @@ vram_group.add_argument("--always-high-vram", action="store_true")
 vram_group.add_argument("--always-normal-vram", action="store_true")
 vram_group.add_argument("--always-low-vram", action="store_true")
 vram_group.add_argument("--always-no-vram", action="store_true")
-vram_group.add_argument("--always-cpu", action="store_true")
+vram_group.add_argument("--always-cpu", type=int, nargs="?", metavar="CPU_NUM_THREADS", const=-1)
 
 
 parser.add_argument("--always-offload-from-vram", action="store_true")

--- a/ldm_patched/modules/model_management.py
+++ b/ldm_patched/modules/model_management.py
@@ -60,7 +60,7 @@ except:
     pass
 
 if args.always_cpu:
-    if type(args.always_cpu) == int and args.always_cpu > 0:
+    if args.always_cpu > 0:
         torch.set_num_threads(args.always_cpu)
     print(f"Running on {torch.get_num_threads()} CPU threads")
     cpu_state = CPUState.CPU

--- a/ldm_patched/modules/model_management.py
+++ b/ldm_patched/modules/model_management.py
@@ -60,6 +60,9 @@ except:
     pass
 
 if args.always_cpu:
+    if type(args.always_cpu) == int and args.always_cpu > 0:
+        torch.set_num_threads(args.always_cpu)
+    print(f"Running on {torch.get_num_threads()} CPU threads")
     cpu_state = CPUState.CPU
 
 def is_intel_xpu():

--- a/readme.md
+++ b/readme.md
@@ -364,7 +364,7 @@ entry_with_update.py  [-h] [--listen [IP]] [--port PORT]
                       [--attention-split | --attention-quad | --attention-pytorch]
                       [--disable-xformers]
                       [--always-gpu | --always-high-vram | --always-normal-vram | 
-                       --always-low-vram | --always-no-vram | --always-cpu]
+                       --always-low-vram | --always-no-vram | --always-cpu [CPU_NUM_THREADS]]
                       [--always-offload-from-vram] [--disable-server-log]
                       [--debug-mode] [--is-windows-embedded-python]
                       [--disable-server-info] [--share] [--preset PRESET]


### PR DESCRIPTION
I have changed the `--always-cpu` argument to integer, if in the command line this argument is followed by a number greater than 0 it will be used in `torch.set_num_threads()` and override the default value.

On my 8 core AMD 7840U which supports 16 threads I noticed I got ~70% CPU utilization while running image generation. As i discovered PyTorch doesn't seem to be benefiting from SMT and sets the number of threads to the number of physical cores.

By increasing the number of threads from default 8 to 15 I received ~5% performance increase and 100% CPU utilization (see screenshots).

8 threads, 78.2 seconds/iteration
![Screenshot 2023-12-26 122338](https://github.com/lllyasviel/Fooocus/assets/7947027/62953b35-f4f8-4457-86c6-118dd567fd10)

15 threads, 72.8% seconds/iteration
![Screenshot 2023-12-26 125136](https://github.com/lllyasviel/Fooocus/assets/7947027/2e0a873f-f7f8-45d6-9a3f-7308100b98b3)

