### PR TITLE
Skip free_memory for describe (interrogate)

### DIFF
--- a/extras/interrogate.py
+++ b/extras/interrogate.py
@@ -47,7 +47,7 @@ class Interrogator:
 
             self.blip_model = ModelPatcher(model, load_device=self.load_device, offload_device=self.offload_device)
 
-        model_management.load_model_gpu(self.blip_model)
+        model_management.load_model_gpu(self.blip_model, should_free_memory=False)
 
         gpu_image = transforms.Compose([
             transforms.ToTensor(),


### PR DESCRIPTION
Closes https://github.com/lllyasviel/Fooocus/issues/1607

This does prevent SDXL from being unloaded while still being used by users in parallel.
Another solution would be to enable the queue for describe click action.