### PR TITLE
make max image number configurable

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -243,10 +243,15 @@ default_advanced_checkbox = get_config_item_or_set_default(
     default_value=False,
     validator=lambda x: isinstance(x, bool)
 )
+default_max_image_number = get_config_item_or_set_default(
+    key='default_max_image_number',
+    default_value=32,
+    validator=lambda x: isinstance(x, int) and x >= 1
+)
 default_image_number = get_config_item_or_set_default(
     key='default_image_number',
     default_value=2,
-    validator=lambda x: isinstance(x, int) and 1 <= x <= 32
+    validator=lambda x: isinstance(x, int) and 1 <= x <= default_max_image_number
 )
 checkpoint_downloads = get_config_item_or_set_default(
     key='checkpoint_downloads',

--- a/webui.py
+++ b/webui.py
@@ -226,7 +226,7 @@ with shared.gradio_root:
                 aspect_ratios_selection = gr.Radio(label='Aspect Ratios', choices=modules.config.available_aspect_ratios,
                                                    value=modules.config.default_aspect_ratio, info='width × height',
                                                    elem_classes='aspect_ratios')
-                image_number = gr.Slider(label='Image Number', minimum=1, maximum=32, step=1, value=modules.config.default_image_number)
+                image_number = gr.Slider(label='Image Number', minimum=1, maximum=modules.config.default_max_image_number, step=1, value=modules.config.default_image_number)
                 negative_prompt = gr.Textbox(label='Negative Prompt', show_label=True, placeholder="Type prompt here.",
                                              info='Describing what you do not want to see.', lines=2,
                                              elem_id='negative_prompt',


### PR DESCRIPTION
See https://github.com/lllyasviel/Fooocus/pull/1248
See https://github.com/lllyasviel/Fooocus/discussions/1511

Uses default_max_image_number as upper limit for default_image_number while keeping the default behaviour if not explicitely adjusted.

⚠️ Increasing default_image_number to a high value (depending on performance selection and GPU, roughly around > 5-10) may cause Gradio to lag heavily though.
Therefore best used in combination with https://github.com/lllyasviel/Fooocus/pull/1013.