### PR TITLE
fix suffix in async_worker callback function

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -40,7 +40,8 @@ def worker():
     from modules.private_logger import log
     from extras.expansion import safe_str
     from modules.util import remove_empty_str, HWC3, resize_image, \
-        get_image_shape_ceil, set_image_shape_ceil, get_shape_ceil, resample_image
+        get_image_shape_ceil, set_image_shape_ceil, get_shape_ceil, resample_image, \
+        ordinal_suffix
     from modules.upscaler import perform_upscale
 
     try:
@@ -712,10 +713,11 @@ def worker():
         async_task.yields.append(['preview', (13, 'Moving model to GPU ...', None)])
 
         def callback(step, x0, x, total_steps, y):
+            suffix = ordinal_suffix(current_task_id + 1)
             done_steps = current_task_id * steps + step
             async_task.yields.append(['preview', (
                 int(15.0 + 85.0 * float(done_steps) / float(all_steps)),
-                f'Step {step}/{total_steps} in the {current_task_id + 1}-th Sampling',
+                f'Step {step}/{total_steps} in the {current_task_id + 1}-{suffix} Sampling',
                 y)])
 
         for current_task_id, task in enumerate(tasks):

--- a/modules/util.py
+++ b/modules/util.py
@@ -165,3 +165,39 @@ def get_files_from_folder(folder_path, exensions=None, name_filter=None):
                 filenames.append(path)
 
     return sorted(filenames, key=lambda x: -1 if os.sep in x else 1)
+
+
+def ordinal_suffix(task_id: int) -> str:
+    """
+    Generate the ordinal suffix for a given task ID.
+
+    Parameters:
+    - task_id (int): The task ID for which the ordinal suffix is to be generated.
+
+    Returns:
+    - str: The ordinal suffix corresponding to the task ID.
+
+    Examples:
+    >>> ordinal_suffix(0)
+    'th'
+
+    >>> ordinal_suffix(1)
+    'st'
+
+    >>> ordinal_suffix(11)
+    'th'
+
+    >>> ordinal_suffix(23)
+    'rd'
+    """
+    task_id = str(task_id)
+    if task_id.endswith(('11','12','13')):
+        return 'th'
+    elif task_id.endswith('1'):
+        return 'st'
+    elif task_id.endswith('2'):
+        return 'nd'
+    elif task_id.endswith('3'):
+        return 'rd'
+    else:
+        return 'th'


### PR DESCRIPTION
Wrote a function ordinal_suffix(task_id) which returns the correct suffix for a given integer.
This fixes the visual error in the callback function  (Step 1/60 in the 1-th Sampling)
The function is written in Fooocus\modules\util.py and imported in worker() together with the rest of the utility needed.
![image](https://github.com/lllyasviel/Fooocus/assets/38398968/78bd16c5-fa2e-48eb-a8e9-1334f72215f1)


Now the callback function will correctly write 1-st, 2-nd, 3-rd etc.