### PR TITLE
fix --disable-in-browser

### DIFF
--- a/args_manager.py
+++ b/args_manager.py
@@ -34,5 +34,7 @@ args_parser.args.always_offload_from_vram = not args_parser.args.disable_offload
 if args_parser.args.disable_analytics:
     import os
     os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
+if args_parser.args.disable_in_browser:
+    args_parser.args.in_browser = False
 
 args = args_parser.args


### PR DESCRIPTION
Currently the `--disable-in-browser` flag is not working because the [set_defaults](https://github.com/cocktailpeanut/Fooocus/blob/4ffe8738afab7571b81864f0c19dc31385fcec80/args_manager.py#L23-L27) line is overriding the `--disable-in-browser` handling that took place here: https://github.com/cocktailpeanut/Fooocus/blob/4ffe8738afab7571b81864f0c19dc31385fcec80/ldm_patched/modules/args_parser.py#L123-L124

To fix this, just add the same handling logic after the `set_defaults`.