### PR TITLE
fix: correctly sort files, display deepest dir level first

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -164,14 +164,14 @@ def get_files_from_folder(folder_path, exensions=None, name_filter=None):
 
     filenames = []
 
-    for root, dirs, files in os.walk(folder_path):
+    for root, dirs, files in os.walk(folder_path, topdown=False):
         relative_path = os.path.relpath(root, folder_path)
         if relative_path == ".":
             relative_path = ""
-        for filename in files:
+        for filename in sorted(files):
             _, file_extension = os.path.splitext(filename)
             if (exensions == None or file_extension.lower() in exensions) and (name_filter == None or name_filter in _):
                 path = os.path.join(relative_path, filename)
                 filenames.append(path)
 
-    return sorted(filenames, key=lambda x: -1 if os.sep in x else 1)
+    return filenames


### PR DESCRIPTION
There is an issue in the file sorting, which has to do with the condition of the lambda. `os.sep` returns correctly, but the sorting of the else condition just appends to the end and beginning, which is wrong.
This PR implements sorting for files when walking as well as `topdown=False` to display subfolders first.

Closes https://github.com/lllyasviel/Fooocus/issues/1618
Relates to https://github.com/lllyasviel/Fooocus/pull/1517

before:
<img width="484" alt="Screenshot 2024-01-07 at 14 17 19" src="https://github.com/lllyasviel/Fooocus/assets/9307310/63873869-c9b0-4bdd-803f-8134b7afaaeb">

after:
<img width="483" alt="Screenshot 2024-01-07 at 14 16 15" src="https://github.com/lllyasviel/Fooocus/assets/9307310/75b87475-d6b8-4b3f-aac0-861d60601090">