### PR TITLE
fix: prevent cutting off overlay

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -198,7 +198,8 @@
 }
 
 #stylePreviewOverlay {
-    display: none;
+    opacity: 0;
+    pointer-events: none;
     width: 128px;
     height: 128px;
     position: fixed;
@@ -208,6 +209,12 @@
     transform: translate(-140px, 20px);
     background-size: cover;
     background-position: center;
+    background-color: rgba(0, 0, 0, 0.3);
     border-radius: 5px;
     z-index: 100;
+    transition: transform 0.1s ease, opacity 0.3s ease;
+}
+
+#stylePreviewOverlay.lower-half {
+    transform: translate(-140px, -140px);
 }

--- a/javascript/script.js
+++ b/javascript/script.js
@@ -158,7 +158,7 @@ function initStylePreviewOverlay() {
         label.removeEventListener("mouseout", onMouseLeave);
         label.addEventListener("mouseout", onMouseLeave);
         overlayVisible = true;
-        overlay.style.display = "block";
+        overlay.style.opacity = "1";
         const originalText = label.querySelector("span").getAttribute("data-original-text");
         const name = originalText || label.querySelector("span").textContent;
         overlay.style.backgroundImage = `url("${samplesPath.replace(
@@ -167,7 +167,7 @@ function initStylePreviewOverlay() {
         ).replaceAll("\\", "\\\\")}")`;
         function onMouseLeave() {
             overlayVisible = false;
-            overlay.style.display = "none";
+            overlay.style.opacity = "0";
             overlay.style.backgroundImage = "";
             label.removeEventListener("mouseout", onMouseLeave);
         }
@@ -176,6 +176,7 @@ function initStylePreviewOverlay() {
         if(!overlayVisible) return;
         overlay.style.left = `${e.clientX}px`;
         overlay.style.top = `${e.clientY}px`;
+        overlay.className = e.clientY > window.innerHeight / 2 ? "lower-half" : "upper-half";
     });
 }
 


### PR DESCRIPTION
Fixes #1816 

The overlay will be positioned on top or below the cursor depending on the position of the cursor in relation to the browser window to prevent it from being cut off.

Bug:
![295025002-e5682628-7312-4125-8080-a69e856d77bf](https://github.com/lllyasviel/Fooocus/assets/1255222/3cf74460-98f1-4625-8f4d-19bc350ff563)

Fix:
Bottom:
![Bildschirmfoto 2024-01-09 um 11 54 52](https://github.com/lllyasviel/Fooocus/assets/1255222/d9552f21-002a-4730-90d4-977b3026ed85)

Top:
![Bildschirmfoto 2024-01-09 um 11 55 02](https://github.com/lllyasviel/Fooocus/assets/1255222/f4764560-2c4d-40fe-ad2b-9ede8721e12c)
