### PR TITLE
Replace opencv-contrib-python with the -headless variant + update to the latest version

### DIFF
--- a/conflicting_old_reqs.txt
+++ b/conflicting_old_reqs.txt
@@ -1,0 +1,1 @@
+opencv-contrib-python

--- a/launch.py
+++ b/launch.py
@@ -33,6 +33,7 @@ def prepare_environment():
     torch_command = os.environ.get('TORCH_COMMAND',
                                    f"pip install torch==2.1.0 torchvision==0.16.0 --extra-index-url {torch_index_url}")
     requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
+    conflicting_old_reqs_file = os.environ.get('CONF_REQS_FILE', "conflicting_old_reqs.txt")
 
     print(f"Python {sys.version}")
     print(f"Fooocus version: {fooocus_version.version}")
@@ -56,7 +57,12 @@ def prepare_environment():
                 run_pip(f"install -U -I --no-deps {xformers_package}", "xformers")
 
     if REINSTALL_ALL or not requirements_met(requirements_file):
-        run_pip(f"install -r \"{requirements_file}\"", "requirements")
+        run(
+            f'{python} -m pip uninstall -yr "{conflicting_old_reqs_file}"',
+            "Uninstalling old conflicting dependencies",
+            "Couldn't uninstall old conflicting dependencies"
+        )
+        run_pip(f'install -r "{requirements_file}"', "requirements")
 
     return
 

--- a/launch.py
+++ b/launch.py
@@ -21,7 +21,6 @@ import fooocus_version
 from build_launcher import build_launcher
 from modules.launch_util import is_installed, run, python, run_pip, requirements_met
 from modules.model_loader import load_file_from_url
-from modules import config
 
 
 REINSTALL_ALL = False
@@ -89,6 +88,7 @@ if args.gpu_device_id is not None:
     os.environ['CUDA_VISIBLE_DEVICES'] = str(args.gpu_device_id)
     print("Set device to:", args.gpu_device_id)
 
+from modules import config
 
 def download_models():
     for file_name, url in vae_approx_filenames:

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -12,7 +12,7 @@ pytorch_lightning==1.9.4
 omegaconf==2.2.3
 gradio==3.41.2
 pygit2==1.12.2
-opencv-contrib-python==4.8.0.74
+opencv-contrib-python-headless==4.9.0.80
 httpx==0.24.1
 onnxruntime==1.16.3
 timm==0.9.2


### PR DESCRIPTION
>    **b.** Packages for server (headless) environments (such as Docker, cloud environments etc.), no GUI library dependencies
>
>    These packages are smaller than the two other packages above because they do not contain any GUI functionality (not compiled with Qt / other GUI components). This means that the packages avoid a heavy dependency chain to X11 libraries and you will have for example smaller Docker images as a result. You should always use these packages if you do not use `cv2.imshow` et al. or you are using some other package (such as PyQt) than OpenCV to create your GUI.

https://github.com/opencv/opencv-python/blob/8ad8ec1bae8aad196b3e9117a4b2b47d58547d47/README.md?plain=1#L42C1-L44C462


Resolves #1882
Fixes #2035