### PR TITLE
chore: add venv mentioned in the readme to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ user_path_config.txt
 user_path_config-deprecated.txt
 /modules/*.png
 /repositories
+/fooocus_env
 /venv
 /tmp
 /ui-config.json


### PR DESCRIPTION
This is for the [Linux (Using Python Venv)](https://github.com/lllyasviel/Fooocus?tab=readme-ov-file#linux-using-python-venv) section in the readme which has instructions to create the `fooocus_env` virtual environment. I updated `.gitignore` instead of the name in the readme for users who might have already followed these instructions.
 
```bash
python3 -m venv fooocus_env
```