### PR TITLE
fix: allow path_outputs to be outside of root dir

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -626,5 +626,6 @@ shared.gradio_root.launch(
     server_port=args_manager.args.port,
     share=args_manager.args.share,
     auth=check_auth if (args_manager.args.share or args_manager.args.listen) and auth_enabled else None,
+    allowed_paths=[modules.config.path_outputs],
     blocked_paths=[constants.AUTH_FILENAME]
 )


### PR DESCRIPTION
Fixes https://github.com/lllyasviel/Fooocus/issues/907 and https://github.com/mashb1t/Fooocus/issues/18

Allows Gradio to serve outputs when folder has been changed in the config.

See 
- https://www.gradio.app/3.50.2/guides/sharing-your-app#security-and-file-access
- https://github.com/gradio-app/gradio/issues/4118