### PR TITLE
fix: add fallback value for default_max_lora_number when default_loras is empty

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -264,7 +264,7 @@ default_loras = get_config_item_or_set_default(
 )
 default_max_lora_number = get_config_item_or_set_default(
     key='default_max_lora_number',
-    default_value=len(default_loras),
+    default_value=len(default_loras) if isinstance(default_loras, list) and len(default_loras) > 0 else 5,
     validator=lambda x: isinstance(x, int) and x >= 1
 )
 default_cfg_scale = get_config_item_or_set_default(


### PR DESCRIPTION
Closes https://github.com/lllyasviel/Fooocus/issues/2427

When default_loras is empty default_max_lora_number also has been set to 0, leading to not being able to see any loras.

With an additional check if default_loras is empty the default value for default_max_lora_number now has a fallback to 5.