### PR TITLE
Fix typo in wildcards/animal.txt

### DIFF
--- a/wildcards/animal.txt
+++ b/wildcards/animal.txt
@@ -18,7 +18,7 @@ Chihuahua
 Chimpanzee
 Chinchilla
 Chipmunk
-Comodo Dragon
+Komodo Dragon
 Cow
 Coyote
 Crocodile


### PR DESCRIPTION
I'm not sure why Github is showing the Zebra line as changed? I only fixed `Komodo Dragon`.