### PR TITLE
feat: match anything in array syntax, not only words and whitespace

### DIFF
--- a/modules/sdxl_styles.py
+++ b/modules/sdxl_styles.py
@@ -94,9 +94,8 @@ def get_words(arrays, totalMult, index):
         return [word] + get_words(arrays[1:], math.floor(totalMult/len(words)), index)
 
 
-
 def apply_arrays(text, index):
-    arrays = re.findall(r'\[\[([\s,\w-]+)\]\]', text)
+    arrays = re.findall(r'\[\[(.*?)\]\]', text)
     if len(arrays) == 0:
         return text
 


### PR DESCRIPTION
Closes https://github.com/lllyasviel/Fooocus/issues/2437

Matches now not only [[blue,red]], but also [[ (red:1.1), (blue:1.2) ]] and enables same seed checks for different prompt weight.