### PR TITLE
fix: parse width and height as int when applying metadata

### DIFF
--- a/modules/meta_parser.py
+++ b/modules/meta_parser.py
@@ -117,8 +117,8 @@ def get_resolution(key: str, fallback: str | None, source_dict: dict, results: l
             results.append(-1)
         else:
             results.append(gr.update())
-            results.append(width)
-            results.append(height)
+            results.append(int(width))
+            results.append(int(height))
     except:
         results.append(gr.update())
         results.append(gr.update())


### PR DESCRIPTION
Fixes https://github.com/lllyasviel/Fooocus/issues/2446

fixes an issue with A1111 metadata scheme where resolution is a string