### PR TITLE
feat: use jpeg instead of jpg, use enums instead of strings

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -8,7 +8,7 @@ import modules.sdxl_styles
 
 from modules.model_loader import load_file_from_url
 from modules.util import get_files_from_folder, makedirs_with_log
-from modules.flags import Performance, MetadataScheme
+from modules.flags import OutputFormat, Performance, MetadataScheme
 
 def get_config_path(key, default_value):
     env = os.getenv(key)
@@ -326,7 +326,7 @@ default_max_image_number = get_config_item_or_set_default(
 default_output_format = get_config_item_or_set_default(
     key='default_output_format',
     default_value='png',
-    validator=lambda x: x in modules.flags.output_formats
+    validator=lambda x: x in OutputFormat.list()
 )
 default_image_number = get_config_item_or_set_default(
     key='default_image_number',

--- a/modules/flags.py
+++ b/modules/flags.py
@@ -67,7 +67,7 @@ default_parameters = {
     cn_ip: (0.5, 0.6), cn_ip_face: (0.9, 0.75), cn_canny: (0.5, 1.0), cn_cpds: (0.5, 1.0)
 }  # stop, weight
 
-output_formats = ['png', 'jpg', 'webp']
+output_formats = ['png', 'jpeg', 'webp']
 
 inpaint_engine_versions = ['None', 'v1', 'v2.5', 'v2.6']
 inpaint_option_default = 'Inpaint or Outpaint (default)'
@@ -89,9 +89,17 @@ metadata_scheme = [
     (f'{MetadataScheme.A1111.value} (plain text)', MetadataScheme.A1111.value),
 ]
 
-lora_count = 5
-
 controlnet_image_count = 4
+
+
+class OutputFormat(Enum):
+    PNG = 'png'
+    JPEG = 'jpeg'
+    WEBP = 'webp'
+
+    @classmethod
+    def list(cls) -> list:
+        return list(map(lambda c: c.value, cls))
 
 
 class Steps(IntEnum):
@@ -120,6 +128,3 @@ class Performance(Enum):
 
     def steps_uov(self) -> int | None:
         return StepsUOV[self.name].value if Steps[self.name] else None
-
-
-performance_selections = Performance.list()

--- a/modules/meta_parser.py
+++ b/modules/meta_parser.py
@@ -117,8 +117,8 @@ def get_resolution(key: str, fallback: str | None, source_dict: dict, results: l
             results.append(-1)
         else:
             results.append(gr.update())
-            results.append(width)
-            results.append(height)
+            results.append(int(width))
+            results.append(int(height))
     except:
         results.append(gr.update())
         results.append(gr.update())

--- a/modules/private_logger.py
+++ b/modules/private_logger.py
@@ -6,8 +6,9 @@ import urllib.parse
 
 from PIL import Image
 from PIL.PngImagePlugin import PngInfo
-from modules.util import generate_temp_filename
+from modules.flags import OutputFormat
 from modules.meta_parser import MetadataParser, get_exif
+from modules.util import generate_temp_filename
 
 log_cache = {}
 
@@ -29,7 +30,7 @@ def log(img, metadata, metadata_parser: MetadataParser | None = None, output_for
     parsed_parameters = metadata_parser.parse_string(metadata.copy()) if metadata_parser is not None else ''
     image = Image.fromarray(img)
 
-    if output_format == 'png':
+    if output_format == OutputFormat.PNG.value:
         if parsed_parameters != '':
             pnginfo = PngInfo()
             pnginfo.add_text('parameters', parsed_parameters)
@@ -37,9 +38,9 @@ def log(img, metadata, metadata_parser: MetadataParser | None = None, output_for
         else:
             pnginfo = None
         image.save(local_temp_filename, pnginfo=pnginfo)
-    elif output_format == 'jpg':
+    elif output_format == OutputFormat.JPEG.value:
         image.save(local_temp_filename, quality=95, optimize=True, progressive=True, exif=get_exif(parsed_parameters, metadata_parser.get_scheme().value) if metadata_parser else Image.Exif())
-    elif output_format == 'webp':
+    elif output_format == OutputFormat.WEBP.value:
         image.save(local_temp_filename, quality=95, lossless=False, exif=get_exif(parsed_parameters, metadata_parser.get_scheme().value) if metadata_parser else Image.Exif())
     else:
         image.save(local_temp_filename)

--- a/webui.py
+++ b/webui.py
@@ -254,7 +254,7 @@ with shared.gradio_root:
         with gr.Column(scale=1, visible=modules.config.default_advanced_checkbox) as advanced_column:
             with gr.Tab(label='Setting'):
                 performance_selection = gr.Radio(label='Performance',
-                                                 choices=modules.flags.performance_selections,
+                                                 choices=flags.Performance.list(),
                                                  value=modules.config.default_performance)
                 aspect_ratios_selection = gr.Radio(label='Aspect Ratios', choices=modules.config.available_aspect_ratios,
                                                    value=modules.config.default_aspect_ratio, info='width × height',
@@ -262,7 +262,7 @@ with shared.gradio_root:
                 image_number = gr.Slider(label='Image Number', minimum=1, maximum=modules.config.default_max_image_number, step=1, value=modules.config.default_image_number)
 
                 output_format = gr.Radio(label='Output Format',
-                                            choices=modules.flags.output_formats,
+                                            choices=flags.OutputFormat.list(),
                                             value=modules.config.default_output_format)
 
                 negative_prompt = gr.Textbox(label='Negative Prompt', show_label=True, placeholder="Type prompt here.",
@@ -427,8 +427,8 @@ with shared.gradio_root:
                         disable_preview = gr.Checkbox(label='Disable Preview', value=False,
                                                       info='Disable preview during generation.')
                         disable_intermediate_results = gr.Checkbox(label='Disable Intermediate Results', 
-                                                      value=modules.config.default_performance == 'Extreme Speed',
-                                                      interactive=modules.config.default_performance != 'Extreme Speed',
+                                                      value=modules.config.default_performance == flags.Performance.EXTREME_SPEED.value,
+                                                      interactive=modules.config.default_performance != flags.Performance.EXTREME_SPEED.value,
                                                       info='Disable intermediate results during generation, only show final gallery.')
                         disable_seed_increment = gr.Checkbox(label='Disable seed increment',
                                                              info='Disable automatic seed increment when image number is > 1.',
@@ -526,9 +526,9 @@ with shared.gradio_root:
                 model_refresh.click(model_refresh_clicked, [], [base_model, refiner_model] + lora_ctrls,
                                     queue=False, show_progress=False)
 
-        performance_selection.change(lambda x: [gr.update(interactive=x != 'Extreme Speed')] * 11 +
-                                               [gr.update(visible=x != 'Extreme Speed')] * 1 +
-                                               [gr.update(interactive=x != 'Extreme Speed', value=x == 'Extreme Speed', )] * 1,
+        performance_selection.change(lambda x: [gr.update(interactive=x != flags.Performance.EXTREME_SPEED.value)] * 11 +
+                                               [gr.update(visible=x != flags.Performance.EXTREME_SPEED.value)] * 1 +
+                                               [gr.update(interactive=x != flags.Performance.EXTREME_SPEED.value, value=x == flags.Performance.EXTREME_SPEED.value, )] * 1,
                                      inputs=performance_selection,
                                      outputs=[
                                          guidance_scale, sharpness, adm_scaler_end, adm_scaler_positive,


### PR DESCRIPTION
Reasoning: 
1. we're already using jpeg to save a jpg file and should sync the filetype accordingly to support more features.
.jpg is just a compatible form for older OS which only support 3 characters for file extensions.
2. enums allow for less typos in strings and allow the actual value behind the enum option to be changed if needed.

- https://www.adobe.com/creativecloud/file-types/image/raster/jpeg-file.html
- https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg
- https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg-2000