### PR TITLE
feat: Scan wildcard subdirectories

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -481,7 +481,7 @@ wildcard_filenames = []
 sdxl_lcm_lora = 'sdxl_lcm_lora.safetensors'
 
 
-def get_model_filenames(folder_paths, extensions=None, name_filter=None, ):
+def get_model_filenames(folder_paths, extensions=None, name_filter=None):
     if extensions is None:
         extensions = ['.pth', '.ckpt', '.bin', '.safetensors', '.fooocus.patch']
     files = []

--- a/modules/config.py
+++ b/modules/config.py
@@ -176,7 +176,9 @@ path_inpaint = get_dir_or_set_default('path_inpaint', '../models/inpaint/')
 path_controlnet = get_dir_or_set_default('path_controlnet', '../models/controlnet/')
 path_clip_vision = get_dir_or_set_default('path_clip_vision', '../models/clip_vision/')
 path_fooocus_expansion = get_dir_or_set_default('path_fooocus_expansion', '../models/prompt_expansion/fooocus_expansion')
+path_wildcards = get_dir_or_set_default('path_wildcards', '../wildcards/')
 path_outputs = get_path_output()
+
 
 def get_config_item_or_set_default(key, default_value, validator, disable_empty_as_none=False):
     global config_dict, visited_keys
@@ -474,21 +476,25 @@ with open(config_example_path, "w", encoding="utf-8") as json_file:
 
 model_filenames = []
 lora_filenames = []
+wildcard_filenames = []
+
 sdxl_lcm_lora = 'sdxl_lcm_lora.safetensors'
 
 
-def get_model_filenames(folder_paths, name_filter=None, extensions=None):
-    extensions = ['.pth', '.ckpt', '.bin', '.safetensors', '.fooocus.patch'] if extensions is None else extensions
+def get_model_filenames(folder_paths, extensions=None, name_filter=None, ):
+    if extensions is None:
+        extensions = ['.pth', '.ckpt', '.bin', '.safetensors', '.fooocus.patch']
     files = []
     for folder in folder_paths:
         files += get_files_from_folder(folder, extensions, name_filter)
     return files
 
 
-def update_all_model_names():
-    global model_filenames, lora_filenames
+def update_files():
+    global model_filenames, lora_filenames, wildcard_filenames
     model_filenames = get_model_filenames(paths_checkpoints)
     lora_filenames = get_model_filenames(paths_loras)
+    wildcard_filenames = get_files_from_folder(path_wildcards, ['.txt'])
     return
 
 
@@ -604,4 +610,4 @@ def downloading_upscale_model():
     return os.path.join(path_upscale_models, 'fooocus_upscaler_s409985e5.bin')
 
 
-update_all_model_names()
+update_files()

--- a/modules/config.py
+++ b/modules/config.py
@@ -477,8 +477,8 @@ lora_filenames = []
 sdxl_lcm_lora = 'sdxl_lcm_lora.safetensors'
 
 
-def get_model_filenames(folder_paths, name_filter=None):
-    extensions = ['.pth', '.ckpt', '.bin', '.safetensors', '.fooocus.patch']
+def get_model_filenames(folder_paths, name_filter=None, extensions=None):
+    extensions = ['.pth', '.ckpt', '.bin', '.safetensors', '.fooocus.patch'] if extensions is None else extensions
     files = []
     for folder in folder_paths:
         files += get_files_from_folder(folder, extensions, name_filter)

--- a/modules/sdxl_styles.py
+++ b/modules/sdxl_styles.py
@@ -6,10 +6,8 @@ import modules.config
 
 from modules.util import get_files_from_folder
 
-
 # cannot use modules.config - validators causing circular imports
 styles_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../sdxl_styles/'))
-wildcards_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../wildcards/'))
 wildcards_max_bfs_depth = 64
 
 
@@ -61,18 +59,17 @@ def apply_style(style, positive):
     return p.replace('{prompt}', positive).splitlines(), n.splitlines()
 
 
-def apply_wildcards(wildcard_text, rng, directory=wildcards_path):
+def apply_wildcards(wildcard_text, rng):
     for _ in range(wildcards_max_bfs_depth):
         placeholders = re.findall(r'__([\w-]+)__', wildcard_text)
         if len(placeholders) == 0:
             return wildcard_text
 
         print(f'[Wildcards] processing: {wildcard_text}')
-        wildcards = modules.config.get_model_filenames([directory], extensions=[".txt"])
         for placeholder in placeholders:
             try:
-                matches = [x for x in wildcards if os.path.splitext(os.path.basename(x))[0] == placeholder]
-                words = open(os.path.join(directory, matches[0]), encoding='utf-8').read().splitlines()
+                matches = [x for x in modules.config.wildcard_filenames if os.path.splitext(os.path.basename(x))[0] == placeholder]
+                words = open(os.path.join(modules.config.path_wildcards, matches[0]), encoding='utf-8').read().splitlines()
                 words = [x for x in words if x != '']
                 assert len(words) > 0
                 wildcard_text = wildcard_text.replace(f'__{placeholder}__', rng.choice(words), 1)
@@ -87,7 +84,7 @@ def apply_wildcards(wildcard_text, rng, directory=wildcards_path):
 
 
 def get_words(arrays, totalMult, index):
-    if(len(arrays) == 1):
+    if len(arrays) == 1:
         return [arrays[0].split(',')[index]]
     else:
         words = arrays[0].split(',')

--- a/modules/sdxl_styles.py
+++ b/modules/sdxl_styles.py
@@ -3,7 +3,8 @@ import re
 import json
 import math
 
-from modules.util import get_files_from_folder
+from modules.util import get_files_from_folder, get_first_occurrence_in_folder
+from glob import glob
 
 
 # cannot use modules.config - validators causing circular imports
@@ -69,7 +70,7 @@ def apply_wildcards(wildcard_text, rng, directory=wildcards_path):
         print(f'[Wildcards] processing: {wildcard_text}')
         for placeholder in placeholders:
             try:
-                words = open(os.path.join(directory, f'{placeholder}.txt'), encoding='utf-8').read().splitlines()
+                words = open(get_first_occurrence_in_folder(directory, f'{placeholder}.txt'), encoding='utf-8').read().splitlines()
                 words = [x for x in words if x != '']
                 assert len(words) > 0
                 wildcard_text = wildcard_text.replace(f'__{placeholder}__', rng.choice(words), 1)

--- a/modules/sdxl_styles.py
+++ b/modules/sdxl_styles.py
@@ -68,10 +68,11 @@ def apply_wildcards(wildcard_text, rng, directory=wildcards_path):
             return wildcard_text
 
         print(f'[Wildcards] processing: {wildcard_text}')
+        wildcards = modules.config.get_model_filenames([directory], extensions=[".txt"])
         for placeholder in placeholders:
             try:
-                file = os.path.join(directory, modules.config.get_model_filenames([directory], placeholder, [".txt"])[0])
-                words = open(file, encoding='utf-8').read().splitlines()
+                matches = [x for x in wildcards if os.path.splitext(os.path.basename(x))[0] == placeholder]
+                words = open(os.path.join(directory, matches[0]), encoding='utf-8').read().splitlines()
                 words = [x for x in words if x != '']
                 assert len(words) > 0
                 wildcard_text = wildcard_text.replace(f'__{placeholder}__', rng.choice(words), 1)

--- a/modules/sdxl_styles.py
+++ b/modules/sdxl_styles.py
@@ -2,9 +2,9 @@ import os
 import re
 import json
 import math
+import modules.config
 
-from modules.util import get_files_from_folder, get_first_occurrence_in_folder
-from glob import glob
+from modules.util import get_files_from_folder
 
 
 # cannot use modules.config - validators causing circular imports
@@ -70,7 +70,8 @@ def apply_wildcards(wildcard_text, rng, directory=wildcards_path):
         print(f'[Wildcards] processing: {wildcard_text}')
         for placeholder in placeholders:
             try:
-                words = open(get_first_occurrence_in_folder(directory, f'{placeholder}.txt'), encoding='utf-8').read().splitlines()
+                file = os.path.join(directory, modules.config.get_model_filenames([directory], placeholder, [".txt"])[0])
+                words = open(file, encoding='utf-8').read().splitlines()
                 words = [x for x in words if x != '']
                 assert len(words) > 0
                 wildcard_text = wildcard_text.replace(f'__{placeholder}__', rng.choice(words), 1)
@@ -82,6 +83,7 @@ def apply_wildcards(wildcard_text, rng, directory=wildcards_path):
 
     print(f'[Wildcards] BFS stack overflow. Current text: {wildcard_text}')
     return wildcard_text
+
 
 def get_words(arrays, totalMult, index):
     if(len(arrays) == 1):

--- a/modules/util.py
+++ b/modules/util.py
@@ -163,7 +163,7 @@ def generate_temp_filename(folder='./outputs/', extension='png'):
     return date_string, os.path.abspath(result), filename
 
 
-def get_files_from_folder(folder_path, exensions=None, name_filter=None):
+def get_files_from_folder(folder_path, extensions=None, name_filter=None):
     if not os.path.isdir(folder_path):
         raise ValueError("Folder path is not a valid directory.")
 
@@ -175,7 +175,7 @@ def get_files_from_folder(folder_path, exensions=None, name_filter=None):
             relative_path = ""
         for filename in sorted(files, key=lambda s: s.casefold()):
             _, file_extension = os.path.splitext(filename)
-            if (exensions is None or file_extension.lower() in exensions) and (name_filter is None or name_filter in _):
+            if (extensions is None or file_extension.lower() in extensions) and (name_filter is None or name_filter in _):
                 path = os.path.join(relative_path, filename)
                 filenames.append(path)
 

--- a/modules/util.py
+++ b/modules/util.py
@@ -182,6 +182,16 @@ def get_files_from_folder(folder_path, extensions=None, name_filter=None):
     return filenames
 
 
+def get_first_occurrence_in_folder(folder_path, filename):
+    if not os.path.isdir(folder_path):
+        raise ValueError("Folder path is not a valid directory.")
+    
+    for root, _, files in os.walk(folder_path, topdown=False):
+        for file in files:
+            if file == filename:
+                return os.path.join(root, file)
+
+
 def calculate_sha256(filename, length=HASH_SHA256_LENGTH) -> str:
     hash_sha256 = sha256()
     blksize = 1024 * 1024

--- a/modules/util.py
+++ b/modules/util.py
@@ -182,16 +182,6 @@ def get_files_from_folder(folder_path, extensions=None, name_filter=None):
     return filenames
 
 
-def get_first_occurrence_in_folder(folder_path, filename):
-    if not os.path.isdir(folder_path):
-        raise ValueError("Folder path is not a valid directory.")
-    
-    for root, _, files in os.walk(folder_path, topdown=False):
-        for file in files:
-            if file == filename:
-                return os.path.join(root, file)
-
-
 def calculate_sha256(filename, length=HASH_SHA256_LENGTH) -> str:
     hash_sha256 = sha256()
     blksize = 1024 * 1024

--- a/webui.py
+++ b/webui.py
@@ -366,7 +366,7 @@ with shared.gradio_root:
                             lora_ctrls += [lora_enabled, lora_model, lora_weight]
 
                 with gr.Row():
-                    model_refresh = gr.Button(label='Refresh', value='\U0001f504 Refresh All Files', variant='secondary', elem_classes='refresh_button')
+                    refresh_files = gr.Button(label='Refresh', value='\U0001f504 Refresh All Files', variant='secondary', elem_classes='refresh_button')
             with gr.Tab(label='Advanced'):
                 guidance_scale = gr.Slider(label='Guidance Scale', minimum=1.0, maximum=30.0, step=0.01,
                                            value=modules.config.default_cfg_scale,
@@ -512,24 +512,23 @@ with shared.gradio_root:
                 def dev_mode_checked(r):
                     return gr.update(visible=r)
 
-
                 dev_mode.change(dev_mode_checked, inputs=[dev_mode], outputs=[dev_tools],
                                 queue=False, show_progress=False)
 
-                def model_refresh_clicked():
-                    modules.config.update_all_model_names()
+                def refresh_files_clicked():
+                    modules.config.update_files()
                     results = [gr.update(choices=modules.config.model_filenames)]
                     results += [gr.update(choices=['None'] + modules.config.model_filenames)]
                     for i in range(modules.config.default_max_lora_number):
                         results += [gr.update(interactive=True), gr.update(choices=['None'] + modules.config.lora_filenames), gr.update()]
                     return results
 
-                model_refresh.click(model_refresh_clicked, [], [base_model, refiner_model] + lora_ctrls,
+                refresh_files.click(refresh_files_clicked, [], [base_model, refiner_model] + lora_ctrls,
                                     queue=False, show_progress=False)
 
         performance_selection.change(lambda x: [gr.update(interactive=x != 'Extreme Speed')] * 11 +
                                                [gr.update(visible=x != 'Extreme Speed')] * 1 +
-                                               [gr.update(interactive=x != 'Extreme Speed', value=x == 'Extreme Speed', )] * 1,
+                                               [gr.update(interactive=x != 'Extreme Speed', value=x == 'Extreme Speed')] * 1,
                                      inputs=performance_selection,
                                      outputs=[
                                          guidance_scale, sharpness, adm_scaler_end, adm_scaler_positive,


### PR DESCRIPTION
Closes #2461 

Allows users to sort their wildcards in folders. Previously Fooocus would only search the base directory.

- Implements functionality for scanning subdirectories within the wildcards directory
- Adds a function for returning the first occurrence of a file within a directory tree