### PR TITLE
feat: add troubleshooting guide to bug report template again

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,6 +21,7 @@ body:
         　5. Try a fresh installation of Fooocus in a different directory - see if a clean installation solves the issue
         Before making a issue report please, check that the issue hasn't been reported recently.
       options:
+        - label: The issue has not been resolved by following the [troubleshooting guide](https://github.com/lllyasviel/Fooocus/blob/main/troubleshoot.md)
         - label: The issue exists on a clean installation of Fooocus
         - label: The issue exists in the current version of Fooocus
         - label: The issue has not been reported before recently


### PR DESCRIPTION
A few issues were popping up lately, which could have been solved by following steps in the troubleshooting guide.
This PR adds the link as checkbox to the bug report template again with the goal of better guiding users to fix their issues themselves.