### PR TITLE
fix: parse seed as string to display correctly in metadata preview

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -856,7 +856,7 @@ def worker():
 
                     d.append(('Sampler', 'sampler', sampler_name))
                     d.append(('Scheduler', 'scheduler', scheduler_name))
-                    d.append(('Seed', 'seed', task['task_seed']))
+                    d.append(('Seed', 'seed', str(task['task_seed'])))
 
                     if freeu_enabled:
                         d.append(('FreeU', 'freeu', str((freeu_b1, freeu_b2, freeu_s1, freeu_s2))))


### PR DESCRIPTION
Fixes https://github.com/lllyasviel/Fooocus/issues/2535

Seed shows up with rounding errors in metadata preview, parsing to string fixes it for preview.
No impoact except for displaying it, as https://github.com/lllyasviel/Fooocus/blob/main/modules/meta_parser.py#L132 already parses to int again.