### PR TITLE
fix: hang on unsupported image

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -894,9 +894,9 @@ def worker():
         time.sleep(0.01)
         if len(async_tasks) > 0:
             task = async_tasks.pop(0)
-            generate_image_grid = task.args.pop(0)
 
             try:
+                generate_image_grid = task.args.pop(0)
                 handler(task)
                 if generate_image_grid:
                     build_image_wall(task)

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -894,9 +894,9 @@ def worker():
         time.sleep(0.01)
         if len(async_tasks) > 0:
             task = async_tasks.pop(0)
+            generate_image_grid = task.args.pop(0)
 
             try:
-                generate_image_grid = task.args.pop(0)
                 handler(task)
                 if generate_image_grid:
                     build_image_wall(task)

--- a/modules/gradio_hijack.py
+++ b/modules/gradio_hijack.py
@@ -17,7 +17,7 @@ from gradio_client.documentation import document, set_documentation_group
 from gradio_client.serializing import ImgSerializable
 from PIL import Image as _Image  # using _ to minimize namespace pollution
 
-from gradio import processing_utils, utils
+from gradio import processing_utils, utils, Error
 from gradio.components.base import IOComponent, _Keywords, Block
 from gradio.deprecation import warn_style_method_deprecation
 from gradio.events import (
@@ -275,7 +275,10 @@ class Image(
                 x, mask = x["image"], x["mask"]
 
         assert isinstance(x, str)
-        im = processing_utils.decode_base64_to_image(x)
+        try:
+            im = processing_utils.decode_base64_to_image(x)
+        except PIL.UnidentifiedImageError:
+            raise Error("Unsupported image type in input")
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             im = im.convert(self.image_mode)

--- a/webui.py
+++ b/webui.py
@@ -28,12 +28,16 @@ def get_task(*args):
 
     return worker.AsyncTask(args=args)
 
-def generate_clicked(task):
+def generate_clicked(task: worker.AsyncTask):
     import ldm_patched.modules.model_management as model_management
 
     with model_management.interrupt_processing_mutex:
         model_management.interrupt_processing = False
     # outputs=[progress_html, progress_window, progress_gallery, gallery]
+
+    if len(task.args) == 0:
+        return
+
     execution_start_time = time.perf_counter()
     finished = False
 


### PR DESCRIPTION
Fixes #2527. 

Displays an error message to the user that the image type is not supported and marks the task as finished to avoid hanging.