### PR TITLE
fix: correctly handle empty lora array in a1111 metadata log scheme

### DIFF
--- a/modules/meta_parser.py
+++ b/modules/meta_parser.py
@@ -377,7 +377,7 @@ class A1111MetadataParser(MetadataParser):
                         data[key] = filename
                         break
 
-        if 'lora_hashes' in data:
+        if 'lora_hashes' in data and data['lora_hashes'] != '':
             lora_filenames = modules.config.lora_filenames.copy()
             if modules.config.sdxl_lcm_lora in lora_filenames:
                 lora_filenames.remove(modules.config.sdxl_lcm_lora)
@@ -431,16 +431,15 @@ class A1111MetadataParser(MetadataParser):
             if key in data:
                 generation_params[self.fooocus_to_a1111[key]] = data[key]
 
-        lora_hashes = []
-        for index, (lora_name, lora_weight, lora_hash) in enumerate(self.loras):
-            # workaround for Fooocus not knowing LoRA name in LoRA metadata
-            lora_hashes.append(f'{lora_name}: {lora_hash}: {lora_weight}')
-        lora_hashes_string = ', '.join(lora_hashes)
+        if len(self.loras) > 0:
+            lora_hashes = []
+            for index, (lora_name, lora_weight, lora_hash) in enumerate(self.loras):
+                # workaround for Fooocus not knowing LoRA name in LoRA metadata
+                lora_hashes.append(f'{lora_name}: {lora_hash}: {lora_weight}')
+            lora_hashes_string = ', '.join(lora_hashes)
+            generation_params[self.fooocus_to_a1111['lora_hashes']] = lora_hashes_string
 
-        generation_params |= {
-            self.fooocus_to_a1111['lora_hashes']: lora_hashes_string,
-            self.fooocus_to_a1111['version']: data['version']
-        }
+        generation_params[self.fooocus_to_a1111['version']] = data['version']
 
         if modules.config.metadata_created_by != '':
             generation_params[self.fooocus_to_a1111['created_by']] = modules.config.metadata_created_by


### PR DESCRIPTION
Fixes https://github.com/lllyasviel/Fooocus/issues/2545

- write: don't write lora hashes to metadata when loras array is empty
- read: check if lora hashes string is present and not empty