### PR TITLE
fix: remove positive prompt from anime prefix

### DIFF
--- a/presets/anime.json
+++ b/presets/anime.json
@@ -34,7 +34,7 @@
     "default_sampler": "dpmpp_2m_sde_gpu",
     "default_scheduler": "karras",
     "default_performance": "Speed",
-    "default_prompt": "1girl, ",
+    "default_prompt": "",
     "default_prompt_negative": "",
     "default_styles": [
         "Fooocus V2",


### PR DESCRIPTION
prevents the prompt from getting overridden when switching presets in browser