### PR TITLE
fix: do not close meta tag in HTML header

### DIFF
--- a/modules/ui_gradio_extensions.py
+++ b/modules/ui_gradio_extensions.py
@@ -39,7 +39,7 @@ def javascript_html():
     head += f'<script type="text/javascript" src="{edit_attention_js_path}"></script>\n'
     head += f'<script type="text/javascript" src="{viewer_js_path}"></script>\n'
     head += f'<script type="text/javascript" src="{image_viewer_js_path}"></script>\n'
-    head += f'<meta name="samples-path" content="{samples_path}"></meta>\n'
+    head += f'<meta name="samples-path" content="{samples_path}" />\n'
 
     if args_manager.args.theme:
         head += f'<script type="text/javascript">set_theme(\"{args_manager.args.theme}\");</script>\n'

--- a/modules/ui_gradio_extensions.py
+++ b/modules/ui_gradio_extensions.py
@@ -39,7 +39,7 @@ def javascript_html():
     head += f'<script type="text/javascript" src="{edit_attention_js_path}"></script>\n'
     head += f'<script type="text/javascript" src="{viewer_js_path}"></script>\n'
     head += f'<script type="text/javascript" src="{image_viewer_js_path}"></script>\n'
-    head += f'<meta name="samples-path" content="{samples_path}" />\n'
+    head += f'<meta name="samples-path" content="{samples_path}">\n'
 
     if args_manager.args.theme:
         head += f'<script type="text/javascript">set_theme(\"{args_manager.args.theme}\");</script>\n'


### PR DESCRIPTION
One `<meta>` tag on the main page had an invalid closing `</meta>` tag, changed it to `<meta />` to match the rest of the page.