### PR TITLE
Revert "fix: use LF as line breaks for Docker entrypoint.sh (#2843)"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,1 +1,33 @@
-#!/bin/bashORIGINALDIR=/content/app# Use predefined DATADIR if it is defined[[ x"${DATADIR}" == "x" ]] && DATADIR=/content/data# Make persistent dir from original dirfunction mklink () {	mkdir -p $DATADIR/$1	ln -s $DATADIR/$1 $ORIGINALDIR}# Copy old files from import dirfunction import () {	(test -d /import/$1 && cd /import/$1 && cp -Rpn . $DATADIR/$1/)}cd $ORIGINALDIR# modelsmklink models# Copy original files(cd $ORIGINALDIR/models.org && cp -Rpn . $ORIGINALDIR/models/)# Import old filesimport models# outputsmklink outputs# Import old filesimport outputs# Start applicationpython launch.py $*
+#!/bin/bash
+
+ORIGINALDIR=/content/app
+# Use predefined DATADIR if it is defined
+[[ x"${DATADIR}" == "x" ]] && DATADIR=/content/data
+
+# Make persistent dir from original dir
+function mklink () {
+	mkdir -p $DATADIR/$1
+	ln -s $DATADIR/$1 $ORIGINALDIR
+}
+
+# Copy old files from import dir
+function import () {
+	(test -d /import/$1 && cd /import/$1 && cp -Rpn . $DATADIR/$1/)
+}
+
+cd $ORIGINALDIR
+
+# models
+mklink models
+# Copy original files
+(cd $ORIGINALDIR/models.org && cp -Rpn . $ORIGINALDIR/models/)
+# Import old files
+import models
+
+# outputs
+mklink outputs
+# Import old files
+import outputs
+
+# Start application
+python launch.py $*


### PR DESCRIPTION
Closes https://github.com/lllyasviel/Fooocus/issues/2863

https://github.com/lllyasviel/Fooocus/discussions/2836 was a false alarm, worked as intended before. Sorry for the fuzz.
This reverts commit d16a54edd69f82158ae7ffe5669618db33a01ac7.