### PR TITLE
feat: UX Colorize aspect ratios, landscape vs portrait

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -510,7 +510,12 @@ def add_ratio(x):
     a, b = x.replace('*', ' ').split(' ')[:2]
     a, b = int(a), int(b)
     g = math.gcd(a, b)
-    return f'{a}×{b} <span style="color: grey;"> \U00002223 {a // g}:{b // g}</span>'
+    portrait_color = "cyan"
+    landscape_color = "green"
+    square_color = "red"
+    color = landscape_color if a > b else portrait_color
+    color = square_color if a == b else color
+    return f'{a}×{b} <span style="color: grey;">\U00002223 </span> <span style="color: {color};"> {a // g}:{b // g}</span>'
 
 
 default_aspect_ratio = add_ratio(default_aspect_ratio)


### PR DESCRIPTION
I found trying to guess if the Aspect Ration was landscape or portrait. Kept getting it wrong! As my computer is super old and slow, this bugged me.

My original idea was to split the manual in three, but that was a hassle to implement without changing a lot of things. This seemed pretty straight forward.

I'm so lazy I didn't add a key, but that would just create more work for localization and it's pretty clear

Screenshot
![image](https://github.com/lllyasviel/Fooocus/assets/176128/06249ffe-2062-4128-8636-1dda9ff46868)
