### PR TITLE
Let gallery start in preview mode [video]

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -111,7 +111,7 @@ with shared.gradio_root:
                                     elem_id='progress-bar', elem_classes='progress-bar')
             gallery = gr.Gallery(label='Gallery', show_label=False, object_fit='contain', visible=True, height=768,
                                  elem_classes=['resizable_area', 'main_view', 'final_gallery', 'image_gallery'],
-                                 elem_id='final_gallery')
+                                 elem_id='final_gallery', preview=True)
             with gr.Row(elem_classes='type_row'):
                 with gr.Column(scale=17):
                     prompt = gr.Textbox(show_label=False, placeholder="Type prompt here or paste parameters.", elem_id='positive_prompt',


### PR DESCRIPTION
Gallery will start in preview mode, which shows all of the images as thumbnails and allows the user to click on them to view them in full size, this will be the logical option when user generate 1 image at time so the generated image will not be minimized for no reason after being generated.  when generated multiple images and since the user will activate it any way to see his images it is also logical to activate it after images being generated.
see attached video 
https://github.com/lllyasviel/Fooocus/assets/89942942/397d8d39-0f80-4f84-92fb-a4d1b220047c

