### PR TITLE
feat: change code owner from @lllyasviel to @mashb1t

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @lllyasviel
+*       @mashb1t


### PR DESCRIPTION
As @lllyasviel has been inactive for ~4 months now (since 2024-01-28, see last commits in https://github.com/lllyasviel/Fooocus/commits/main/?author=lllyasviel) it's just more practical to maintain the code effectively when I'm also the one pinged on new PRs / issues in general, especially when being the only active collaborator / maintainer on this repository.

@lllyasviel if you read this, your feedback is more than welcome. I'm planning to publish 2.4.0-RC1 today, so I'd like to merge this adjustment in 2.4.0 (non-rc).