### PR TITLE
feat: adjust line ending default config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure that shell scripts always use lf line endings, e.g. entrypoint.sh for docker
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
closes https://github.com/lllyasviel/Fooocus/pull/2985
discussion https://github.com/lllyasviel/Fooocus/discussions/2836

always use `LF` instead of `CRLF` for *.sh files line entrypoint.sh