### PR TITLE
feat: add inpaint brush color picker

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -72,7 +72,7 @@ progress::after {
 
 .progress-bar span {
     text-align: right;
-    width: 200px;
+    width: 215px;
 }
 
 .type_row{
@@ -399,4 +399,8 @@ progress::after {
   text-align: center;
   border-radius: 5px 5px 0px 0px;
   display: none; /* remove this to enable tooltip in preview image */
+}
+
+#inpaint_brush_color input[type=color]{
+  background: none;
 }

--- a/webui.py
+++ b/webui.py
@@ -524,13 +524,20 @@ with shared.gradio_root:
                         inpaint_mask_upload_checkbox = gr.Checkbox(label='Enable Mask Upload', value=False)
                         invert_mask_checkbox = gr.Checkbox(label='Invert Mask', value=False)
 
+                        inpaint_mask_color = gr.ColorPicker(label='Inpaint brush color', value='#FFFFFF', elem_id='inpaint_brush_color')
+
                         inpaint_ctrls = [debugging_inpaint_preprocessor, inpaint_disable_initial_latent, inpaint_engine,
                                          inpaint_strength, inpaint_respective_field,
                                          inpaint_mask_upload_checkbox, invert_mask_checkbox, inpaint_erode_or_dilate]
 
                         inpaint_mask_upload_checkbox.change(lambda x: gr.update(visible=x),
-                                                           inputs=inpaint_mask_upload_checkbox,
-                                                           outputs=inpaint_mask_image, queue=False, show_progress=False)
+                                                            inputs=inpaint_mask_upload_checkbox,
+                                                            outputs=inpaint_mask_image, queue=False,
+                                                            show_progress=False)
+
+                        inpaint_mask_color.change(lambda x: gr.update(brush_color=x), inputs=inpaint_mask_color,
+                                                  outputs=inpaint_input_image,
+                                                  queue=False, show_progress=False)
 
                     with gr.Tab(label='FreeU'):
                         freeu_enabled = gr.Checkbox(label='Enabled', value=False)


### PR DESCRIPTION
relates to https://github.com/lllyasviel/Fooocus/issues/2660

Workaround as tool color-sketch applies changes directly to the image canvas and not the mask canvas.

Color picker is not correctly implemented in Gradio 3.41.2 => does always get displayed as separate containers and not merged with other elements.

![screencapture-localhost-7865-2024-05-26-11_32_30](https://github.com/lllyasviel/Fooocus/assets/9307310/b9ee642b-9594-4d3a-8084-37149eb47c8c)
