### PR TITLE
fix: do not set textContent on undefined when no translation was given

### DIFF
--- a/javascript/localization.js
+++ b/javascript/localization.js
@@ -81,9 +81,12 @@ function refresh_style_localization() {
 }
 
 function refresh_aspect_ratios_label(value) {
-    label = document.querySelector('#aspect_ratios_accordion div span[data-original-text="Aspect Ratios"]')
-    translation = getTranslation("Aspect Ratios")
-    label.textContent = translation + " " + htmlDecode(value)
+    label = document.querySelector('#aspect_ratios_accordion div span[data-original-text="Aspect Ratios"]');
+    translation = getTranslation("Aspect Ratios");
+    if (typeof translation == "undefined") {
+        translation = "Aspect Ratios";
+    }
+    label.textContent = translation + " " + htmlDecode(value);
 }
 
 function localizeWholePage() {


### PR DESCRIPTION
![image](https://github.com/lllyasviel/Fooocus/assets/9307310/68acff85-84d3-4989-b4a7-9d6b72c36c70)

Adds type check for undefined, fall back to label "Aspect Ratios".