### PR TITLE
feat: adjust playground_v2.5 preset

### DIFF
--- a/presets/playground_v2.5.json
+++ b/presets/playground_v2.5.json
@@ -37,9 +37,7 @@
     "default_prompt": "",
     "default_prompt_negative": "",
     "default_styles": [
-        "Fooocus V2",
-        "Fooocus Enhance",
-        "Fooocus Sharp"
+        "Fooocus V2"
     ],
     "default_aspect_ratio": "1024*1024",
     "checkpoint_downloads": {

--- a/presets/playground_v2.5.json
+++ b/presets/playground_v2.5.json
@@ -29,7 +29,7 @@
             1.0
         ]
     ],
-    "default_cfg_scale": 3.0,
+    "default_cfg_scale": 2.0,
     "default_sample_sharpness": 2.0,
     "default_sampler": "dpmpp_2m",
     "default_scheduler": "edm_playground_v2.5",


### PR DESCRIPTION
 - reduce cfg of from 3 to 2 to prevent oversaturation
 - remove style presets Fooocus Enhance and Fooocus Sharp