### PR TITLE
hotfix: add missing method in performance enum

### DIFF
--- a/modules/flags.py
+++ b/modules/flags.py
@@ -156,6 +156,10 @@ class Performance(Enum):
         return list(map(lambda c: c.value, cls))
 
     @classmethod
+    def values(cls) -> list:
+        return list(map(lambda c: c.value, cls))
+
+    @classmethod
     def by_steps(cls, steps: int | str):
         return cls[Steps(int(steps)).name]
 


### PR DESCRIPTION
adds method Performance.values(), fixes https://github.com/lllyasviel/Fooocus/commit/3e453501f702a7d419dd4b4a2067ab6a7daca495