### PR TITLE
fix: allow reading of metadata from jpeg, jpg and webp again

### DIFF
--- a/modules/meta_parser.py
+++ b/modules/meta_parser.py
@@ -604,9 +604,8 @@ def get_metadata_parser(metadata_scheme: MetadataScheme) -> MetadataParser:
             raise NotImplementedError
 
 
-def read_info_from_image(filepath) -> tuple[str | None, MetadataScheme | None]:
-    with Image.open(filepath) as image:
-        items = (image.info or {}).copy()
+def read_info_from_image(file) -> tuple[str | None, MetadataScheme | None]:
+    items = (file.info or {}).copy()
 
     parameters = items.pop('parameters', None)
     metadata_scheme = items.pop('fooocus_scheme', None)
@@ -615,7 +614,7 @@ def read_info_from_image(filepath) -> tuple[str | None, MetadataScheme | None]:
     if parameters is not None and is_json(parameters):
         parameters = json.loads(parameters)
     elif exif is not None:
-        exif = image.getexif()
+        exif = file.getexif()
         # 0x9286 = UserComment
         parameters = exif.get(0x9286, None)
         # 0x927C = MakerNote

--- a/webui.py
+++ b/webui.py
@@ -339,12 +339,12 @@ with shared.gradio_root:
 
                     with gr.TabItem(label='Metadata') as metadata_tab:
                         with gr.Column():
-                            metadata_input_image = grh.Image(label='For images created by Fooocus', source='upload', type='filepath')
+                            metadata_input_image = grh.Image(label='For images created by Fooocus', source='upload', type='pil')
                             metadata_json = gr.JSON(label='Metadata')
                             metadata_import_button = gr.Button(value='Apply Metadata')
 
-                        def trigger_metadata_preview(filepath):
-                            parameters, metadata_scheme = modules.meta_parser.read_info_from_image(filepath)
+                        def trigger_metadata_preview(file):
+                            parameters, metadata_scheme = modules.meta_parser.read_info_from_image(file)
 
                             results = {}
                             if parameters is not None:
@@ -995,8 +995,8 @@ with shared.gradio_root:
 
         load_parameter_button.click(modules.meta_parser.load_parameter_button_click, inputs=[prompt, state_is_generating, inpaint_mode], outputs=load_data_outputs, queue=False, show_progress=False)
 
-        def trigger_metadata_import(filepath, state_is_generating):
-            parameters, metadata_scheme = modules.meta_parser.read_info_from_image(filepath)
+        def trigger_metadata_import(file, state_is_generating):
+            parameters, metadata_scheme = modules.meta_parser.read_info_from_image(file)
             if parameters is None:
                 print('Could not find metadata in the image!')
                 parsed_parameters = {}


### PR DESCRIPTION
fixes https://github.com/mashb1t/Fooocus/issues/57

allow metadata reading from jpeg and webp again
see https://github.com/mashb1t/Fooocus/discussions/56#discussioncomment-10077227

also massively improves metadata read speed