### PR TITLE
[Feature Request]: Added Clear Button that clears the prompt textbox.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -99,7 +99,7 @@ div:has(> #positive_prompt) {
 }
 
 .advanced_check_row {
-  width: 330px !important;
+  width: 360px !important;
 }
 
 .min_check {

--- a/webui.py
+++ b/webui.py
@@ -178,9 +178,16 @@ with shared.gradio_root:
                     stop_button.click(stop_clicked, inputs=currentTask, outputs=currentTask, queue=False, show_progress=False, _js='cancelGenerateForever')
                     skip_button.click(skip_clicked, inputs=currentTask, outputs=currentTask, queue=False, show_progress=False)
             with gr.Row(elem_classes='advanced_check_row'):
+                clear_button = gr.Button(label="Clear", value="Clear", container=False, elem_classes='min_check', elem_id='clear_button')
                 input_image_checkbox = gr.Checkbox(label='Input Image', value=False, container=False, elem_classes='min_check')
                 enhance_checkbox = gr.Checkbox(label='Enhance', value=modules.config.default_enhance_checkbox, container=False, elem_classes='min_check')
                 advanced_checkbox = gr.Checkbox(label='Advanced', value=modules.config.default_advanced_checkbox, container=False, elem_classes='min_check')
+
+                def clear_clicked():
+                    promptText = ""
+                    return promptText
+
+                clear_button.click(clear_clicked, outputs=prompt)
             with gr.Row(visible=False) as image_input_panel:
                 with gr.Tabs():
                     with gr.TabItem(label='Upscale or Variation') as uov_tab:


### PR DESCRIPTION
A Simple Button that clears the prompt textbox simplify the process when copying and pasting prompts.
![foooocus_clear_button](https://github.com/user-attachments/assets/06dfeb66-2dda-45bb-9ad5-2e1edc6060c1)
