### PR TITLE
fix: correctly debug preprocessor again

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -158,7 +158,7 @@ class AsyncTask:
 async_tasks = []
 
 
-class EarlyReturnException:
+class EarlyReturnException(BaseException):
     pass
 
 


### PR DESCRIPTION
fixes https://github.com/lllyasviel/Fooocus/issues/3327
as discussed in https://github.com/lllyasviel/Fooocus/discussions/3323

add missing inheritance for EarlyReturnException from BaseException to correctly throw and catch