### PR TITLE
remove the printout of the clipboard content from to_clipboard function

### DIFF
--- a/modules/private_logger.py
+++ b/modules/private_logger.py
@@ -86,7 +86,7 @@ def log(img, metadata, metadata_parser: MetadataParser | None = None, output_for
             document.execCommand('copy')
             document.body.removeChild(textArea)
         }
-        alert('Copied to Clipboard!\\nPaste to prompt area to load parameters.\\nCurrent clipboard content is:\\n\\n' + txt);
+        alert('Copied to Clipboard!\\nPaste to prompt area to load parameters.');
         }
         </script>"""
     )


### PR DESCRIPTION
I find it very annoying, that the entire clipboard content is shown to me, which can be quite long. You can see the same content in the html overview and you will probably paste it a second later and see it there too.