### PR TITLE
full path to load safety checker model cause OSError

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -953,9 +953,9 @@ def downloading_safety_checker_model():
     load_file_from_url(
         url='https://huggingface.co/mashb1t/misc/resolve/main/stable-diffusion-safety-checker.bin',
         model_dir=path_safety_checker,
-        file_name='stable-diffusion-safety-checker.bin'
+        file_name='pytorch_model.bin'
     )
-    return os.path.join(path_safety_checker, 'stable-diffusion-safety-checker.bin')
+    return os.path.join(path_safety_checker)
 
 
 def download_sam_model(sam_model: str) -> str:


### PR DESCRIPTION
 OSError: Incorrect path_or_model_id: 'D:\ComfyUI\models\safety_checker\stable-diffusion-safety-checker.bin'. Please provide either the path to a local folder or the repo_id of a model on the Hub.

it should be a directory and model named pytorch_model.bin