### PR TITLE
Fix M series Mac bug

### DIFF
--- a/ldm_patched/pfn/architecture/RRDB.py
+++ b/ldm_patched/pfn/architecture/RRDB.py
@@ -281,6 +281,7 @@ class RRDBNet(nn.Module):
         return max(*nbs) + 1
 
     def forward(self, x):
+        x = x.contiguous()
         if self.shuffle_factor:
             _, _, h, w = x.size()
             mod_pad_h = (


### PR DESCRIPTION
Fooocus inpainting on Mac M series inconsistently produces a bug in sizing/reshaping, this fix was found in ComfyUI repo comments but contains the same core to fix. 

Explanation here
https://github.com/comfyanonymous/ComfyUI/issues/5075#issuecomment-2451867268

Here's the error 
```
Upscaling image with shape (712, 781, 3) ...
Traceback (most recent call last):
  File "/Users/dyspop/Code/Fooocus/modules/async_worker.py", line 1471, in worker
    handler(task)
  File "/Users/dyspop/miniconda3/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/miniconda3/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/Code/Fooocus/modules/async_worker.py", line 1193, in handler
    denoising_strength, initial_latent, width, height, current_progress = apply_inpaint(async_task,
                                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/Code/Fooocus/modules/async_worker.py", line 486, in apply_inpaint
    inpaint_worker.current_task = inpaint_worker.InpaintWorker(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/Code/Fooocus/modules/inpaint_worker.py", line 162, in __init__
    self.interested_image = perform_upscale(self.interested_image)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/Code/Fooocus/modules/upscaler.py", line 30, in perform_upscale
    img = opImageUpscaleWithModel.upscale(model, img)[0]
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/Code/Fooocus/ldm_patched/contrib/external_upscale_model.py", line 54, in upscale
    s = ldm_patched.modules.utils.tiled_scale(in_img, lambda a: upscale_model(a), tile_x=tile, tile_y=tile, overlap=overlap, upscale_amount=upscale_model.scale, pbar=pbar)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/miniconda3/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/Code/Fooocus/ldm_patched/modules/utils.py", line 418, in tiled_scale
    ps = function(s_in).to(output_device)
         ^^^^^^^^^^^^^^
  File "/Users/dyspop/Code/Fooocus/ldm_patched/contrib/external_upscale_model.py", line 54, in <lambda>
    s = ldm_patched.modules.utils.tiled_scale(in_img, lambda a: upscale_model(a), tile_x=tile, tile_y=tile, overlap=overlap, upscale_amount=upscale_model.scale, pbar=pbar)
                                                                ^^^^^^^^^^^^^^^^
  File "/Users/dyspop/miniconda3/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1740, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/miniconda3/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/Code/Fooocus/ldm_patched/pfn/architecture/RRDB.py", line 296, in forward
    return x[:, :, : h * self.scale, : w * self.scale]
       ^^^^^^^^^^^^^
  File "/Users/dyspop/miniconda3/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1740, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/miniconda3/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/miniconda3/lib/python3.12/site-packages/torch/nn/modules/container.py", line 250, in forward
    input = module(input)
            ^^^^^^^^^^^^^
  File "/Users/dyspop/miniconda3/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1740, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/miniconda3/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/miniconda3/lib/python3.12/site-packages/torch/nn/modules/conv.py", line 554, in forward
    return self._conv_forward(input, self.weight, self.bias)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dyspop/miniconda3/lib/python3.12/site-packages/torch/nn/modules/conv.py", line 549, in _conv_forward
    return F.conv2d(
           ^^^^^^^^^
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```
