### PR TITLE
Added --output-folder argument for specifying custom image output directory

### DIFF
--- a/args_manager.py
+++ b/args_manager.py
@@ -39,6 +39,66 @@ args_parser.parser.add_argument("--always-download-new-model", action='store_tru
 
 args_parser.parser.add_argument("--rebuild-hash-cache", help="Generates missing model and LoRA hashes.",
                                 type=int, nargs="?", metavar="CPU_NUM_THREADS", const=-1)
+import ldm_patched.modules.args_parser as args_parser
+
+args_parser.parser.add_argument("--share", action='store_true', help="Set whether to share on Gradio.")
+
+args_parser.parser.add_argument("--preset", type=str, default=None, help="Apply specified UI preset.")
+args_parser.parser.add_argument("--disable-preset-selection", action='store_true',
+                                help="Disables preset selection in Gradio.")
+
+args_parser.parser.add_argument("--language", type=str, default='default',
+                                help="Translate UI using json files in [language] folder. "
+                                  "For example, [--language example] will use [language/example.json] for translation.")
+
+# For example, https://github.com/lllyasviel/Fooocus/issues/849
+args_parser.parser.add_argument("--disable-offload-from-vram", action="store_true",
+                                help="Force loading models to vram when the unload can be avoided. "
+                                  "Some Mac users may need this.")
+
+args_parser.parser.add_argument("--theme", type=str, help="launches the UI with light or dark theme", default=None)
+args_parser.parser.add_argument("--disable-image-log", action='store_true',
+                                help="Prevent writing images and logs to the outputs folder.")
+
+args_parser.parser.add_argument("--disable-analytics", action='store_true',
+                                help="Disables analytics for Gradio.")
+
+args_parser.parser.add_argument("--disable-metadata", action='store_true',
+                                help="Disables saving metadata to images.")
+
+args_parser.parser.add_argument("--disable-preset-download", action='store_true',
+                                help="Disables downloading models for presets", default=False)
+
+args_parser.parser.add_argument("--disable-enhance-output-sorting", action='store_true',
+                                help="Disables enhance output sorting for final image gallery.")
+
+args_parser.parser.add_argument("--enable-auto-describe-image", action='store_true',
+                                help="Enables automatic description of uov and enhance image when prompt is empty", default=False)
+
+args_parser.parser.add_argument("--always-download-new-model", action='store_true',
+                                help="Always download newer models", default=False)
+
+args_parser.parser.add_argument("--rebuild-hash-cache", help="Generates missing model and LoRA hashes.",
+                                type=int, nargs="?", metavar="CPU_NUM_THREADS", const=-1)
+
+# New argument: Specify custom output folder
+args_parser.parser.add_argument("--output-folder", type=str, default="outputs",
+                                help="Specify a custom output folder for generated images.")
+
+args_parser.parser.set_defaults(
+    disable_cuda_malloc=True,
+    in_browser=True,
+    port=None
+)
+
+args_parser.args = args_parser.parser.parse_args()
+
+# (Disable by default because of issues like https://github.com/lllyasviel/Fooocus/issues/724)
+args_parser.args.always_offload_from_vram = not args_parser.args.disable_offload_from_vram
+
+if args_parser.args.disable_analytics:
+    import os
+    os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 
 args_parser.parser.set_defaults(
     disable_cuda_malloc=True,


### PR DESCRIPTION
This PR adds a new argument (--output-folder) that allows users to specify a custom output directory for generated images.

- Default output folder is "outputs".
- This helps users organize their generated images in a custom location.

Closes #<issue_number_if_applicable>
