### PR TITLE
Update Dockerfile and Docker Requirements to Support 50 Series Cards (Cuda 12.8+)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM nvidia/cuda:12.4.1-base-ubuntu22.04
+#Original
+#FROM nvidia/cuda:12.4.1-base-ubuntu22.04
+#Cuda 12.8/13
+FROM nvidia/cuda:12.8.1-base-ubuntu22.04
 ENV DEBIAN_FRONTEND noninteractive
 ENV CMDARGS --listen
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
-#Original
-#FROM nvidia/cuda:12.4.1-base-ubuntu22.04
-#Cuda 12.8/13
 FROM nvidia/cuda:12.8.1-base-ubuntu22.04
 ENV DEBIAN_FRONTEND noninteractive
 ENV CMDARGS --listen

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,32 @@
 FROM nvidia/cuda:12.8.1-base-ubuntu22.04
-ENV DEBIAN_FRONTEND noninteractive
-ENV CMDARGS --listen
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CMDARGS=--listen
 
 RUN apt-get update -y && \
-	apt-get install -y curl libgl1 libglib2.0-0 python3-pip python-is-python3 git && \
-	apt-get clean && \
-	rm -rf /var/lib/apt/lists/*
+    apt-get install -y curl libgl1 libglib2.0-0 python3-pip python-is-python3 git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY requirements_docker.txt requirements_versions.txt /tmp/
 RUN pip install --no-cache-dir -r /tmp/requirements_docker.txt -r /tmp/requirements_versions.txt && \
-	rm -f /tmp/requirements_docker.txt /tmp/requirements_versions.txt
+    rm -f /tmp/requirements_docker.txt /tmp/requirements_versions.txt
+
+# Force old-compatible web stack for this Fooocus build
+RUN pip install --no-cache-dir \
+    "gradio==3.41.2" \
+    "starlette==0.27.0" \
+    "fastapi==0.103.2" \
+    "pydantic==1.10.13"
+
+
 RUN pip install --no-cache-dir xformers==0.0.23 --no-dependencies
-RUN curl -fsL -o /usr/local/lib/python3.10/dist-packages/gradio/frpc_linux_amd64_v0.2 https://cdn-media.huggingface.co/frpc-gradio-0.2/frpc_linux_amd64 && \
-	chmod +x /usr/local/lib/python3.10/dist-packages/gradio/frpc_linux_amd64_v0.2
+
+RUN curl -fsL -o /usr/local/lib/python3.10/dist-packages/gradio/frpc_linux_amd64_v0.2 \
+    https://cdn-media.huggingface.co/frpc-gradio-0.2/frpc_linux_amd64 && \
+    chmod +x /usr/local/lib/python3.10/dist-packages/gradio/frpc_linux_amd64_v0.2
 
 RUN adduser --disabled-password --gecos '' user && \
-	mkdir -p /content/app /content/data
+    mkdir -p /content/app /content/data
 
 COPY entrypoint.sh /content/
 RUN chown -R user:user /content

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -1,2 +1,2 @@
-torch==2.1.0
-torchvision==0.16.0
+torch==2.8.0
+torchvision==0.23.0


### PR DESCRIPTION
I made these two changes to the Dockerfile and the docker_requrirements.txt, and was able to run the `docker build`  and successfully make a docker image that works on 50 series cards.

Tested it on my Nvidia 5060 TI 16GB and it works.