### PR TITLE
fix: resolve TypeError when using Starlette ≥0.29 with Gradio 3.41.2

### DIFF
--- a/modules/ui_gradio_extensions.py
+++ b/modules/ui_gradio_extensions.py
@@ -52,12 +52,21 @@ def css_html():
     head = f'<link rel="stylesheet" property="stylesheet" href="{style_css_path}">'
     return head
 
-
 def reload_javascript():
     js = javascript_html()
     css = css_html()
 
     def template_response(*args, **kwargs):
+        # Gradio 3.41.2 gọi old-style: TemplateResponse("index.html", {"request": req, ...})
+        # Starlette mới expect:          TemplateResponse(request, "index.html", {"request": req, ...})
+        # → args bị lệch → dict bị truyền vào jinja2 làm template name → crash
+        if args and isinstance(args[0], str) and len(args) > 1 and isinstance(args[1], dict):
+            name = args[0]
+            context = args[1]
+            request = context.get("request")
+            if request is not None:
+                args = (request, name, context) + args[2:]
+
         res = GradioTemplateResponseOriginal(*args, **kwargs)
         res.body = res.body.replace(b'</head>', f'{js}</head>'.encode("utf8"))
         res.body = res.body.replace(b'</body>', f'{css}</body>'.encode("utf8"))


### PR DESCRIPTION
## Problem

When running Fooocus with newer versions of `starlette` (≥ 0.29), the app crashes on every page load with:

```
TypeError: unhashable type: 'dict'
```

<details>
<summary>Full traceback</summary>
<span style="color:red">ERROR: </span>Exception in ASGI application
Traceback (most recent call last):
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 415, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/fastapi/applications.py", line 1163, in __call__
    await super().__call__(scope, receive, send)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/applications.py", line 90, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/middleware/cors.py", line 88, in __call__
    await self.app(scope, receive, send)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/routing.py", line 660, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/routing.py", line 680, in app
    await route.handle(scope, receive, send)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/fastapi/routing.py", line 134, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/fastapi/routing.py", line 120, in app
    response = await f(request)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/fastapi/routing.py", line 674, in app
    raw_response = await run_endpoint_function(
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/fastapi/routing.py", line 330, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/concurrency.py", line 32, in run_in_threadpool
    return await anyio.to_thread.run_sync(func)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/anyio/to_thread.py", line 63, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 2518, in run_sync_in_worker_thread
    return await future
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 1002, in run
    result = context.run(func, *args)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/gradio/routes.py", line 282, in main
    return templates.TemplateResponse(
  File "/Users/Documents/Fooocus/modules/ui_gradio_extensions.py", line 61, in template_response
    res = GradioTemplateResponseOriginal(*args, **kwargs)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/templating.py", line 148, in TemplateResponse
    template = self.get_template(name)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/starlette/templating.py", line 115, in get_template
    return self.env.get_template(name)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/jinja2/environment.py", line 997, in get_template
    return self._load_template(name, globals)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/jinja2/environment.py", line 947, in _load_template
    template = self.cache.get(cache_key)
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/jinja2/utils.py", line 544, in get
    return self[key]
  File "/Users/miniconda3/envs/fooocus/lib/python3.10/site-packages/jinja2/utils.py", line 582, in __getitem__
    rv = self._mapping[key]
TypeError: unhashable type: 'dict'
</details>
Full traceback ends at:
```
File ".../modules/ui_gradio_extensions.py", line 61, in template_response
    res = GradioTemplateResponseOriginal(*args, **kwargs)
...
TypeError: unhashable type: 'dict'
```

## Root Cause

`starlette` changed the signature of `TemplateResponse` between versions:

| Version | Signature |
|---|---|
| Old (≤ 0.28) | `TemplateResponse(name: str, context: dict, ...)` |
| New (≥ 0.29) | `TemplateResponse(request: Request, name: str, context: dict, ...)` |
Gradio 3.41.2 still calls the **old-style** signature.
When `GradioTemplateResponseOriginal` is called, starlette passes the `context dict`
as the template `name` into Jinja2's cache lookup — which expects a hashable string — causing the crash.