### PR TITLE
Colab: Fix Fooocus UI crash caused by FastAPI/Starlette dependency mismatch 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,11 +109,11 @@ See also the common problems and troubleshoots [here](troubleshoot.md).
 
 ### Colab
 
-(Last tested - 2024 Aug 12 by [mashb1t](https://github.com/mashb1t))
+(Last tested - 2026 July 07 by [Amit Gajare](https://github.com/Amitgajare2))
 
 | Colab | Info
 | --- | --- |
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lllyasviel/Fooocus/blob/main/fooocus_colab.ipynb) | Fooocus Official
+[![Open In Colab](https://colab.research.google.com/drive/1V9MtY-SPbBv0GRWDAooqPnMDOb0gR4a0?usp=sharing) | Fooocus Official
 
 In Colab, you can modify the last line to `!python entry_with_update.py --share --always-high-vram` or `!python entry_with_update.py --share --always-high-vram --preset anime` or `!python entry_with_update.py --share --always-high-vram --preset realistic` for Fooocus Default/Anime/Realistic Edition.
 

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,8 @@ See also the common problems and troubleshoots [here](troubleshoot.md).
 
 | Colab | Info
 | --- | --- |
-[![Open In Colab](https://colab.research.google.com/drive/1V9MtY-SPbBv0GRWDAooqPnMDOb0gR4a0?usp=sharing) | Fooocus Official
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1V9MtY-SPbBv0GRWDAooqPnMDOb0gR4a0?usp=sharing) | Fooocus Official
+
 
 In Colab, you can modify the last line to `!python entry_with_update.py --share --always-high-vram` or `!python entry_with_update.py --share --always-high-vram --preset anime` or `!python entry_with_update.py --share --always-high-vram --preset realistic` for Fooocus Default/Anime/Realistic Edition.
 


### PR DESCRIPTION
Issue fixed:
Fixed repeated ASGI crash on Colab where Fooocus starts but the Gradio UI fails with:
TypeError: unhashable type: 'dict'

Cause:
Dependency mismatch between Gradio 3.41.2 and newer FastAPI/Starlette/Jinja stack installed in Colab.

Fix:
Pinned compatible FastAPI, Starlette, Uvicorn, and Pydantic versions in the Colab setup before launching Fooocus.

new colab 
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/7250eb93-34ff-40d2-ae01-24a69b3576bc" />

running demo
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/cbb40845-bfab-4686-8b39-d13a46b9fac2" />
